### PR TITLE
事件推送问题求教

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+jdk:
+  - oraclejdk7
+
+script: "mvn clean deploy -Dmaven.test.skip=true"
+
+branches:
+  only:
+    - develop
+
+notifications:
+  email:
+    - chanjarster@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - oraclejdk7
 
-script: "mvn clean deploy -Dmaven.test.skip=true"
+script: "mvn clean install -Dmaven.test.skip=true"
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-weixin-java-tools
+weixin-java-tools[![Build Status](https://travis-ci.org/chanjarster/weixin-java-tools.svg?branch=develop)](https://travis-ci.org/chanjarster/weixin-java-tools)
 ===========
 
 微信公众号、企业号Java SDK。

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-weixin-java-tools[![Build Status](https://travis-ci.org/chanjarster/weixin-java-tools.svg?branch=develop)](https://travis-ci.org/chanjarster/weixin-java-tools)
+weixin-java-tools
+
+[![Build Status](https://travis-ci.org/chanjarster/weixin-java-tools.svg?branch=develop)](https://travis-ci.org/chanjarster/weixin-java-tools)
+![Maven Central](https://img.shields.io/maven-central/v/me.chanjar/weixin-java-parent.svg)
+
 ===========
 
 微信公众号、企业号Java SDK。

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>me.chanjar</groupId>
   <artifactId>weixin-java-parent</artifactId>
-  <version>1.1.2-SNAPSHOT</version>
+  <version>1.1.2</version>
   <packaging>pom</packaging>
   <name>WeiXin Java Tools - Parent</name>
   <description>微信公众号、企业号上级POM</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>me.chanjar</groupId>
   <artifactId>weixin-java-parent</artifactId>
-  <version>1.1.1</version>
+  <version>1.1.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>WeiXin Java Tools - Parent</name>
   <description>微信公众号、企业号上级POM</description>

--- a/weixin-java-common/pom.xml
+++ b/weixin-java-common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>me.chanjar</groupId>
     <artifactId>weixin-java-parent</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>weixin-java-common</artifactId>

--- a/weixin-java-common/pom.xml
+++ b/weixin-java-common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>me.chanjar</groupId>
     <artifactId>weixin-java-parent</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.2</version>
   </parent>
 
   <artifactId>weixin-java-common</artifactId>

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/api/WxErrorExceptionHandler.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/api/WxErrorExceptionHandler.java
@@ -1,4 +1,4 @@
-package me.chanjar.weixin.common.util;
+package me.chanjar.weixin.common.api;
 
 import me.chanjar.weixin.common.exception.WxErrorException;
 

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/api/WxMessageDuplicateChecker.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/api/WxMessageDuplicateChecker.java
@@ -1,4 +1,4 @@
-package me.chanjar.weixin.common.util;
+package me.chanjar.weixin.common.api;
 
 /**
  * <pre>

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/api/WxMessageInMemoryDuplicateChecker.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/api/WxMessageInMemoryDuplicateChecker.java
@@ -1,4 +1,4 @@
-package me.chanjar.weixin.common.util;
+package me.chanjar.weixin.common.api;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxAccessToken.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxAccessToken.java
@@ -2,7 +2,9 @@ package me.chanjar.weixin.common.bean;
 
 import me.chanjar.weixin.common.util.json.WxGsonBuilder;
 
-public class WxAccessToken {
+import java.io.Serializable;
+
+public class WxAccessToken implements Serializable {
 
   private String accessToken;
   

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxJsapiSignature.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxJsapiSignature.java
@@ -1,9 +1,11 @@
 package me.chanjar.weixin.common.bean;
 
+import java.io.Serializable;
+
 /**
  * jspai signature
  */
-public class WxJsapiSignature {
+public class WxJsapiSignature implements Serializable {
 
   private String noncestr;
 

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxJsapiSignature.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxJsapiSignature.java
@@ -1,9 +1,9 @@
-package me.chanjar.weixin.mp.bean.result;
+package me.chanjar.weixin.common.bean;
 
 /**
  * jspai signature
  */
-public class WxMpJsapiSignature {
+public class WxJsapiSignature {
 
   private String noncestr;
 

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxMenu.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxMenu.java
@@ -2,6 +2,7 @@ package me.chanjar.weixin.common.bean;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,7 +13,7 @@ import me.chanjar.weixin.common.util.json.WxGsonBuilder;
  * @author Daniel Qian
  *
  */
-public class WxMenu {
+public class WxMenu implements Serializable {
 
   private List<WxMenuButton> buttons = new ArrayList<WxMenuButton>();
 

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/result/WxError.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/result/WxError.java
@@ -2,13 +2,15 @@ package me.chanjar.weixin.common.bean.result;
 
 import me.chanjar.weixin.common.util.json.WxGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * 微信错误码说明
  * http://mp.weixin.qq.com/wiki/index.php?title=全局返回码说明
  * @author Daniel Qian
  *
  */
-public class WxError {
+public class WxError implements Serializable {
 
   private int errorCode;
   

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/result/WxMediaUploadResult.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/result/WxMediaUploadResult.java
@@ -2,7 +2,9 @@ package me.chanjar.weixin.common.bean.result;
 
 import me.chanjar.weixin.common.util.json.WxGsonBuilder;
 
-public class WxMediaUploadResult {
+import java.io.Serializable;
+
+public class WxMediaUploadResult implements Serializable {
 
   private String type;
   private String mediaId;

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/LogExceptionHandler.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/LogExceptionHandler.java
@@ -1,5 +1,6 @@
 package me.chanjar.weixin.common.util;
 
+import me.chanjar.weixin.common.api.WxErrorExceptionHandler;
 import me.chanjar.weixin.common.exception.WxErrorException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/RandomUtils.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/RandomUtils.java
@@ -1,0 +1,17 @@
+package me.chanjar.weixin.common.util;
+
+public class RandomUtils {
+
+  private static final String RANDOM_STR = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+  private static final java.util.Random RANDOM = new java.util.Random();
+
+  public static String getRandomStr() {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 16; i++) {
+      sb.append(RANDOM_STR.charAt(RANDOM.nextInt(RANDOM_STR.length())));
+    }
+    return sb.toString();
+  }
+
+}

--- a/weixin-java-common/src/test/java/me/chanjar/weixin/common/util/WxMessageInMemoryDuplicateCheckerTest.java
+++ b/weixin-java-common/src/test/java/me/chanjar/weixin/common/util/WxMessageInMemoryDuplicateCheckerTest.java
@@ -1,5 +1,6 @@
 package me.chanjar.weixin.common.util;
 
+import me.chanjar.weixin.common.api.WxMessageInMemoryDuplicateChecker;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/weixin-java-cp/pom.xml
+++ b/weixin-java-cp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.chanjar</groupId>
         <artifactId>weixin-java-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.2</version>
     </parent>
 
     <artifactId>weixin-java-cp</artifactId>

--- a/weixin-java-cp/pom.xml
+++ b/weixin-java-cp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.chanjar</groupId>
         <artifactId>weixin-java-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weixin-java-cp</artifactId>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpConfigStorage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpConfigStorage.java
@@ -22,6 +22,20 @@ public interface WxCpConfigStorage {
 
   public void updateAccessToken(String accessToken, int expiresIn);
 
+  public String getJsapiTicket();
+
+  public boolean isJsapiTicketExpired();
+
+  /**
+   * 强制将jsapi ticket过期掉
+   */
+  public void expireJsapiTicket();
+
+  /**
+   * 应该是线程安全的
+   * @param jsapiTicket
+   */
+  public void updateJsapiTicket(String jsapiTicket, int expiresInSeconds);
 
   public String getCorpId();
   

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpInMemoryConfigStorage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpInMemoryConfigStorage.java
@@ -25,6 +25,9 @@ public class WxCpInMemoryConfigStorage implements WxCpConfigStorage {
   protected volatile String http_proxy_username;
   protected volatile String http_proxy_password;
 
+  protected volatile String jsapiTicket;
+  protected volatile long jsapiTicketExpiresTime;
+
   public String getAccessToken() {
     return this.accessToken;
   }
@@ -44,6 +47,37 @@ public class WxCpInMemoryConfigStorage implements WxCpConfigStorage {
   public synchronized void updateAccessToken(String accessToken, int expiresInSeconds) {
     this.accessToken = accessToken;
     this.expiresTime = System.currentTimeMillis() + (expiresInSeconds - 200) * 1000l;
+  }
+
+  @Override
+  public String getJsapiTicket() {
+    return jsapiTicket;
+  }
+
+  public void setJsapiTicket(String jsapiTicket) {
+    this.jsapiTicket = jsapiTicket;
+  }
+
+  public long getJsapiTicketExpiresTime() {
+    return jsapiTicketExpiresTime;
+  }
+
+  public void setJsapiTicketExpiresTime(long jsapiTicketExpiresTime) {
+    this.jsapiTicketExpiresTime = jsapiTicketExpiresTime;
+  }
+
+  public boolean isJsapiTicketExpired() {
+    return System.currentTimeMillis() > this.jsapiTicketExpiresTime;
+  }
+
+  public synchronized void updateJsapiTicket(String jsapiTicket, int expiresInSeconds) {
+    this.jsapiTicket = jsapiTicket;
+    // 预留200秒的时间
+    this.jsapiTicketExpiresTime = System.currentTimeMillis() + (expiresInSeconds - 200) * 1000l;
+  }
+
+  public void expireJsapiTicket() {
+    this.jsapiTicketExpiresTime = 0;
   }
 
   public String getCorpId() {
@@ -153,6 +187,8 @@ public class WxCpInMemoryConfigStorage implements WxCpConfigStorage {
         ", http_proxy_port=" + http_proxy_port +
         ", http_proxy_username='" + http_proxy_username + '\'' +
         ", http_proxy_password='" + http_proxy_password + '\'' +
+        ", jsapiTicket='" + jsapiTicket + '\'' +
+        ", jsapiTicketExpiresTime='" + jsapiTicketExpiresTime + '\'' +
         '}';
   }
 

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMessageRouter.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMessageRouter.java
@@ -5,9 +5,9 @@ import me.chanjar.weixin.common.session.InternalSessionManager;
 import me.chanjar.weixin.common.session.StandardSessionManager;
 import me.chanjar.weixin.common.session.WxSessionManager;
 import me.chanjar.weixin.common.util.LogExceptionHandler;
-import me.chanjar.weixin.common.util.WxErrorExceptionHandler;
-import me.chanjar.weixin.common.util.WxMessageDuplicateChecker;
-import me.chanjar.weixin.common.util.WxMessageInMemoryDuplicateChecker;
+import me.chanjar.weixin.common.api.WxErrorExceptionHandler;
+import me.chanjar.weixin.common.api.WxMessageDuplicateChecker;
+import me.chanjar.weixin.common.api.WxMessageInMemoryDuplicateChecker;
 import me.chanjar.weixin.cp.bean.WxCpXmlMessage;
 import me.chanjar.weixin.cp.bean.WxCpXmlOutMessage;
 import org.slf4j.Logger;
@@ -87,8 +87,8 @@ public class WxCpMessageRouter {
 
   /**
    * <pre>
-   * 设置自定义的 {@link me.chanjar.weixin.common.util.WxMessageDuplicateChecker}
-   * 如果不调用该方法，默认使用 {@link me.chanjar.weixin.common.util.WxMessageInMemoryDuplicateChecker}
+   * 设置自定义的 {@link me.chanjar.weixin.common.api.WxMessageDuplicateChecker}
+   * 如果不调用该方法，默认使用 {@link me.chanjar.weixin.common.api.WxMessageInMemoryDuplicateChecker}
    * </pre>
    * @param messageDuplicateChecker
    */
@@ -109,7 +109,7 @@ public class WxCpMessageRouter {
 
   /**
    * <pre>
-   * 设置自定义的{@link me.chanjar.weixin.common.util.WxErrorExceptionHandler}
+   * 设置自定义的{@link me.chanjar.weixin.common.api.WxErrorExceptionHandler}
    * 如果不调用该方法，默认使用 {@link me.chanjar.weixin.common.util.LogExceptionHandler}
    * </pre>
    * @param exceptionHandler

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMessageRouter.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMessageRouter.java
@@ -204,7 +204,7 @@ public class WxCpMessageRouter {
       messageId = String.valueOf(wxMessage.getCreateTime())
           + "-" +String.valueOf(wxMessage.getAgentId() == null ? "" : wxMessage.getAgentId())
           + "-" + wxMessage.getFromUserName()
-          + "-" + String.valueOf(wxMessage.getEventKey() == null ? "" : wxMessage.getEvent());
+          + "-" + String.valueOf(wxMessage.getEventKey() == null ? "" : wxMessage.getEventKey());
       ;
     } else {
       messageId = String.valueOf(wxMessage.getMsgId());

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMessageRouter.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMessageRouter.java
@@ -204,7 +204,8 @@ public class WxCpMessageRouter {
       messageId = String.valueOf(wxMessage.getCreateTime())
           + "-" +String.valueOf(wxMessage.getAgentId() == null ? "" : wxMessage.getAgentId())
           + "-" + wxMessage.getFromUserName()
-          + "-" + String.valueOf(wxMessage.getEventKey() == null ? "" : wxMessage.getEventKey());
+          + "-" + String.valueOf(wxMessage.getEventKey() == null ? "" : wxMessage.getEventKey())
+          + "-" + String.valueOf(wxMessage.getEvent() == null ? "" : wxMessage.getEvent())
       ;
     } else {
       messageId = String.valueOf(wxMessage.getMsgId());

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMessageRouterRule.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMessageRouterRule.java
@@ -2,7 +2,7 @@ package me.chanjar.weixin.cp.api;
 
 import me.chanjar.weixin.common.exception.WxErrorException;
 import me.chanjar.weixin.common.session.WxSessionManager;
-import me.chanjar.weixin.common.util.WxErrorExceptionHandler;
+import me.chanjar.weixin.common.api.WxErrorExceptionHandler;
 import me.chanjar.weixin.cp.bean.WxCpXmlMessage;
 import me.chanjar.weixin.cp.bean.WxCpXmlOutMessage;
 

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
@@ -1,5 +1,6 @@
 package me.chanjar.weixin.cp.api;
 
+import me.chanjar.weixin.common.bean.WxJsapiSignature;
 import me.chanjar.weixin.common.bean.WxMenu;
 import me.chanjar.weixin.common.bean.result.WxMediaUploadResult;
 import me.chanjar.weixin.common.exception.WxErrorException;
@@ -66,6 +67,38 @@ public interface WxCpService {
    * @throws me.chanjar.weixin.common.exception.WxErrorException
    */
   String getAccessToken(boolean forceRefresh) throws WxErrorException;
+
+  /**
+   * 获得jsapi_ticket,不强制刷新jsapi_ticket
+   * @see #getJsapiTicket(boolean)
+   * @return
+   * @throws WxErrorException
+   */
+  public String getJsapiTicket() throws WxErrorException;
+
+  /**
+   * <pre>
+   * 获得jsapi_ticket
+   * 获得时会检查jsapiToken是否过期，如果过期了，那么就刷新一下，否则就什么都不干
+   *
+   * 详情请见：http://qydev.weixin.qq.com/wiki/index.php?title=微信JS接口#.E9.99.84.E5.BD.951-JS-SDK.E4.BD.BF.E7.94.A8.E6.9D.83.E9.99.90.E7.AD.BE.E5.90.8D.E7.AE.97.E6.B3.95
+   * </pre>
+   * @param forceRefresh 强制刷新
+   * @return
+   * @throws WxErrorException
+   */
+  public String getJsapiTicket(boolean forceRefresh) throws WxErrorException;
+
+  /**
+   * <pre>
+   * 创建调用jsapi时所需要的签名
+   *
+   * 详情请见：http://qydev.weixin.qq.com/wiki/index.php?title=微信JS接口#.E9.99.84.E5.BD.951-JS-SDK.E4.BD.BF.E7.94.A8.E6.9D.83.E9.99.90.E7.AD.BE.E5.90.8D.E7.AE.97.E6.B3.95
+   * </pre>
+   * @param url       url
+   * @return
+   */
+  public WxJsapiSignature createJsapiSignature(String url) throws WxErrorException;
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
@@ -353,10 +353,11 @@ public interface WxCpService {
    * 构造oauth2授权的url连接
    * 详情请见: http://qydev.weixin.qq.com/wiki/index.php?title=企业获取code
    * </pre>
+   * @param redirectUri
    * @param state
    * @return code
    */
-  String oauth2buildAuthorizationUrl(String state);
+  String oauth2buildAuthorizationUrl(String redirectUri, String state);
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpServiceImpl.java
@@ -412,10 +412,10 @@ public class WxCpServiceImpl implements WxCpService {
   }
 
   @Override
-  public String oauth2buildAuthorizationUrl(String state) {
+  public String oauth2buildAuthorizationUrl(String redirectUri, String state) {
     String url = "https://open.weixin.qq.com/connect/oauth2/authorize?" ;
     url += "appid=" + wxCpConfigStorage.getCorpId();
-    url += "&redirect_uri=" + URIUtil.encodeURIComponent(wxCpConfigStorage.getOauth2redirectUri());
+    url += "&redirect_uri=" + URIUtil.encodeURIComponent(redirectUri);
     url += "&response_type=code";
     url += "&scope=snsapi_base";
     if (state != null) {

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpServiceImpl.java
@@ -140,7 +140,7 @@ public class WxCpServiceImpl implements WxCpService {
     if (wxCpConfigStorage.isJsapiTicketExpired()) {
       synchronized (globalJsapiTicketRefreshLock) {
         if (wxCpConfigStorage.isJsapiTicketExpired()) {
-          String url = "https://api.weixin.qq.com/cgi-bin/ticket/getticket?type=jsapi";
+          String url = "https://qyapi.weixin.qq.com/cgi-bin/get_jsapi_ticket";
           String responseContent = execute(new SimpleGetRequestExecutor(), url, null);
           JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
           JsonObject tmpJsonObject = tmpJsonElement.getAsJsonObject();

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpServiceImpl.java
@@ -427,22 +427,13 @@ public class WxCpServiceImpl implements WxCpService {
 
   @Override
   public String[] oauth2getUserInfo(String code) throws WxErrorException {
-    String url = "https://qyapi.weixin.qq.com/cgi-bin/user/getuserinfo?";
-    url += "access_token=" + wxCpConfigStorage.getAccessToken();
-    url += "&code=" + code;
-    url += "&agendid=" + wxCpConfigStorage.getAgentId();
-
-    try {
-      RequestExecutor<String, String> executor = new SimpleGetRequestExecutor();
-      String responseText = executor.execute(getHttpclient(), httpProxy, url, null);
-      JsonElement je = Streams.parse(new JsonReader(new StringReader(responseText)));
-      JsonObject jo = je.getAsJsonObject();
-      return new String[] {GsonHelper.getString(jo, "UserId"), GsonHelper.getString(jo, "DeviceId")};
-    } catch (ClientProtocolException e) {
-      throw new RuntimeException(e);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    String url = "https://qyapi.weixin.qq.com/cgi-bin/user/getuserinfo?"
+                    + "code=" + code
+                    + "&agendid=" + wxCpConfigStorage.getAgentId();
+    String responseText = get(url, null);
+    JsonElement je = Streams.parse(new JsonReader(new StringReader(responseText)));
+    JsonObject jo = je.getAsJsonObject();
+    return new String[] {GsonHelper.getString(jo, "UserId"), GsonHelper.getString(jo, "DeviceId")};
   }
 
   @Override

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpDepart.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpDepart.java
@@ -2,12 +2,14 @@ package me.chanjar.weixin.cp.bean;
 
 import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * 微信部门
  *
  * @author Daniel Qian
  */
-public class WxCpDepart {
+public class WxCpDepart implements Serializable {
 
   private Integer id;
   private String name;

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpMessage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpMessage.java
@@ -3,6 +3,7 @@ package me.chanjar.weixin.cp.bean;
 import me.chanjar.weixin.cp.bean.messagebuilder.*;
 import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,7 +12,7 @@ import java.util.List;
  * @author Daniel Qian
  *
  */
-public class WxCpMessage {
+public class WxCpMessage implements Serializable {
 
   private String toUser;
   private String toParty;

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTag.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTag.java
@@ -2,10 +2,12 @@ package me.chanjar.weixin.cp.bean;
 
 import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * Created by Daniel Qian
  */
-public class WxCpTag {
+public class WxCpTag implements Serializable {
 
   private String id;
 

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpUser.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpUser.java
@@ -2,6 +2,7 @@ package me.chanjar.weixin.cp.bean;
 
 import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,7 +11,7 @@ import java.util.List;
  *
  * @author Daniel Qian
  */
-public class WxCpUser {
+public class WxCpUser implements Serializable {
 
   private String userId;
   private String name;

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpXmlMessage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpXmlMessage.java
@@ -10,6 +10,7 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +26,7 @@ import java.util.List;
  * @author Daniel Qian
  */
 @XStreamAlias("xml")
-public class WxCpXmlMessage {
+public class WxCpXmlMessage implements Serializable {
 
   ///////////////////////
   // 以下都是微信推送过来的消息的xml的element所对应的属性

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/demo/WxCpDemoServer.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/demo/WxCpDemoServer.java
@@ -62,7 +62,7 @@ public class WxCpDemoServer {
         @Override
         public WxCpXmlOutMessage handle(WxCpXmlMessage wxMessage, Map<String, Object> context,
             WxCpService wxCpService, WxSessionManager sessionManager) {
-          String href = "<a href=\"" + wxCpService.oauth2buildAuthorizationUrl(null)
+          String href = "<a href=\"" + wxCpService.oauth2buildAuthorizationUrl(wxCpConfigStorage.getOauth2redirectUri(), null)
               + "\">测试oauth2</a>";
           return WxCpXmlOutMessage
               .TEXT()

--- a/weixin-java-mp/pom.xml
+++ b/weixin-java-mp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.chanjar</groupId>
         <artifactId>weixin-java-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
     <artifactId>weixin-java-mp</artifactId>
     <name>WeiXin Java Tools - MP</name>

--- a/weixin-java-mp/pom.xml
+++ b/weixin-java-mp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.chanjar</groupId>
         <artifactId>weixin-java-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.2</version>
     </parent>
     <artifactId>weixin-java-mp</artifactId>
     <name>WeiXin Java Tools - MP</name>

--- a/weixin-java-mp/src/main/java/TestNonAtomicLongAssignment.java
+++ b/weixin-java-mp/src/main/java/TestNonAtomicLongAssignment.java
@@ -1,0 +1,68 @@
+/**
+ * Created by qianjia on 15/1/25.
+ */
+public class TestNonAtomicLongAssignment {
+
+  private static final long HI = 1l << 32;
+  private static final long LO = 1l;
+
+  private static final long TEST_NUMBER = HI | LO;
+
+  private static long assignee = 0l;
+
+  public static void main(String[] args) {
+
+    Thread writer = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        while (true) {
+          assignee = TEST_NUMBER;
+        }
+      }
+    });
+    writer.setDaemon(true);
+
+    Thread reader = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        long i = 0;
+        while (true) {
+          i++;
+          long test = assignee;
+          if (test != TEST_NUMBER) {
+            System.out.print(i + " times:" + toBin(test));
+            break;
+          }
+        }
+      }
+    });
+
+    //    Thread worker = new Thread(new Runnable() {
+    //      @Override
+    //      public void run() {
+    //        double d = 89009808877238948224343435452333323113131313133434434341212323232424243434335354232390490189190420928348910913094983.323334401928d;
+    //        while(true) {
+    //          Math.cbrt(d);
+    //          d = d - 1l;
+    //        }
+    //      }
+    //    });
+    //    worker.setDaemon(true);
+    //    worker.start();
+
+    writer.start();
+    reader.start();
+
+  }
+
+  public static String toBin(long n) {
+    StringBuilder sb = new StringBuilder(Long.toBinaryString(n));
+    int padding = 64 - sb.length();
+    while (padding > 0) {
+      sb.insert(0, '0');
+      padding--;
+    }
+    return sb.toString();
+  }
+
+}

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpInMemoryConfigStorage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpInMemoryConfigStorage.java
@@ -51,6 +51,18 @@ public class WxMpInMemoryConfigStorage implements WxMpConfigStorage {
     return jsapiTicket;
   }
 
+  public void setJsapiTicket(String jsapiTicket) {
+    this.jsapiTicket = jsapiTicket;
+  }
+
+  public long getJsapiTicketExpiresTime() {
+    return jsapiTicketExpiresTime;
+  }
+
+  public void setJsapiTicketExpiresTime(long jsapiTicketExpiresTime) {
+    this.jsapiTicketExpiresTime = jsapiTicketExpiresTime;
+  }
+
   public boolean isJsapiTicketExpired() {
     return System.currentTimeMillis() > this.jsapiTicketExpiresTime;
   }
@@ -167,5 +179,4 @@ public class WxMpInMemoryConfigStorage implements WxMpConfigStorage {
         ", jsapiTicketExpiresTime='" + jsapiTicketExpiresTime + '\'' +
         '}';
   }
-
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpMessageRouter.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpMessageRouter.java
@@ -203,7 +203,7 @@ public class WxMpMessageRouter {
     if (wxMessage.getMsgId() == null) {
       messageId = String.valueOf(wxMessage.getCreateTime())
           + "-" + wxMessage.getFromUserName()
-          + "-" + String.valueOf(wxMessage.getEventKey() == null ? "" : wxMessage.getEvent());
+          + "-" + String.valueOf(wxMessage.getEventKey() == null ? "" : wxMessage.getEventKey());
       ;
     } else {
       messageId = String.valueOf(wxMessage.getMsgId());

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpMessageRouter.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpMessageRouter.java
@@ -5,9 +5,9 @@ import me.chanjar.weixin.common.session.InternalSessionManager;
 import me.chanjar.weixin.common.session.StandardSessionManager;
 import me.chanjar.weixin.common.session.WxSessionManager;
 import me.chanjar.weixin.common.util.LogExceptionHandler;
-import me.chanjar.weixin.common.util.WxErrorExceptionHandler;
-import me.chanjar.weixin.common.util.WxMessageDuplicateChecker;
-import me.chanjar.weixin.common.util.WxMessageInMemoryDuplicateChecker;
+import me.chanjar.weixin.common.api.WxErrorExceptionHandler;
+import me.chanjar.weixin.common.api.WxMessageDuplicateChecker;
+import me.chanjar.weixin.common.api.WxMessageInMemoryDuplicateChecker;
 import me.chanjar.weixin.mp.bean.WxMpXmlMessage;
 import me.chanjar.weixin.mp.bean.WxMpXmlOutMessage;
 import org.slf4j.Logger;
@@ -87,8 +87,8 @@ public class WxMpMessageRouter {
 
   /**
    * <pre>
-   * 设置自定义的 {@link me.chanjar.weixin.common.util.WxMessageDuplicateChecker}
-   * 如果不调用该方法，默认使用 {@link me.chanjar.weixin.common.util.WxMessageInMemoryDuplicateChecker}
+   * 设置自定义的 {@link me.chanjar.weixin.common.api.WxMessageDuplicateChecker}
+   * 如果不调用该方法，默认使用 {@link me.chanjar.weixin.common.api.WxMessageInMemoryDuplicateChecker}
    * </pre>
    * @param messageDuplicateChecker
    */
@@ -109,7 +109,7 @@ public class WxMpMessageRouter {
 
   /**
    * <pre>
-   * 设置自定义的{@link me.chanjar.weixin.common.util.WxErrorExceptionHandler}
+   * 设置自定义的{@link me.chanjar.weixin.common.api.WxErrorExceptionHandler}
    * 如果不调用该方法，默认使用 {@link me.chanjar.weixin.common.util.LogExceptionHandler}
    * </pre>
    * @param exceptionHandler

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpMessageRouter.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpMessageRouter.java
@@ -203,7 +203,8 @@ public class WxMpMessageRouter {
     if (wxMessage.getMsgId() == null) {
       messageId = String.valueOf(wxMessage.getCreateTime())
           + "-" + wxMessage.getFromUserName()
-          + "-" + String.valueOf(wxMessage.getEventKey() == null ? "" : wxMessage.getEventKey());
+          + "-" + String.valueOf(wxMessage.getEventKey() == null ? "" : wxMessage.getEventKey())
+          + "-" + String.valueOf(wxMessage.getEvent() == null ? "" : wxMessage.getEvent())
       ;
     } else {
       messageId = String.valueOf(wxMessage.getMsgId());

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpMessageRouterRule.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpMessageRouterRule.java
@@ -2,7 +2,7 @@ package me.chanjar.weixin.mp.api;
 
 import me.chanjar.weixin.common.exception.WxErrorException;
 import me.chanjar.weixin.common.session.WxSessionManager;
-import me.chanjar.weixin.common.util.WxErrorExceptionHandler;
+import me.chanjar.weixin.common.api.WxErrorExceptionHandler;
 import me.chanjar.weixin.mp.bean.WxMpXmlMessage;
 import me.chanjar.weixin.mp.bean.WxMpXmlOutMessage;
 

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
@@ -1,10 +1,9 @@
 package me.chanjar.weixin.mp.api;
 
 import me.chanjar.weixin.common.bean.WxMenu;
+import me.chanjar.weixin.common.bean.WxJsapiSignature;
 import me.chanjar.weixin.common.bean.result.WxMediaUploadResult;
 import me.chanjar.weixin.common.exception.WxErrorException;
-import me.chanjar.weixin.common.session.WxSession;
-import me.chanjar.weixin.common.session.WxSessionManager;
 import me.chanjar.weixin.common.util.http.RequestExecutor;
 import me.chanjar.weixin.mp.bean.*;
 import me.chanjar.weixin.mp.bean.result.*;
@@ -86,7 +85,7 @@ public interface WxMpService {
    * @param url       url
    * @return
    */
-  public WxMpJsapiSignature createJsapiSignature(String url) throws WxErrorException;
+  public WxJsapiSignature createJsapiSignature(String url) throws WxErrorException;
 
   /**
    * <pre>

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
@@ -422,6 +422,16 @@ public interface WxMpService {
   public boolean oauth2validateAccessToken(WxMpOAuth2AccessToken oAuth2AccessToken);
 
   /**
+   * <pre>
+   * 获取微信服务器IP地址
+   * http://mp.weixin.qq.com/wiki/0/2ad4b6bfd29f30f71d39616c2a0fcedc.html
+   * </pre>
+   * @return
+   * @throws WxErrorException
+   */
+  String[] getCallbackIP() throws WxErrorException;
+
+  /**
    * 当本Service没有实现某个API的时候，可以用这个，针对所有微信API中的GET请求
    * @param url
    * @param queryParam

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
@@ -11,13 +11,16 @@ import me.chanjar.weixin.mp.bean.result.*;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 
 /**
  * 微信API的Service
  */
 public interface WxMpService {
-  
+
+  public static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
   /**
    * <pre>
    * 验证推送过来的消息的正确性
@@ -430,6 +433,30 @@ public interface WxMpService {
    * @throws WxErrorException
    */
   String[] getCallbackIP() throws WxErrorException;
+
+  /**
+   * <pre>
+   * 获取用户增减数据
+   * http://mp.weixin.qq.com/wiki/3/ecfed6e1a0a03b5f35e5efac98e864b7.html
+   * </pre>
+   * @param beginDate 最大时间跨度7天
+   * @param endDate   endDate不能早于begingDate
+   * @return
+   * @throws WxErrorException
+   */
+  List<WxMpUserSummary> getUserSummary(Date beginDate, Date endDate) throws WxErrorException;
+
+  /**
+   * <pre>
+   * 获取累计用户数据
+   * http://mp.weixin.qq.com/wiki/3/ecfed6e1a0a03b5f35e5efac98e864b7.html
+   * </pre>
+   * @param beginDate 最大时间跨度7天
+   * @param endDate   endDate不能早于begingDate
+   * @return
+   * @throws WxErrorException
+   */
+  List<WxMpUserCumulate> getUserCumulate(Date beginDate, Date endDate) throws WxErrorException;
 
   /**
    * 当本Service没有实现某个API的时候，可以用这个，针对所有微信API中的GET请求

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -7,11 +7,13 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import me.chanjar.weixin.common.bean.WxAccessToken;
 import me.chanjar.weixin.common.bean.WxMenu;
+import me.chanjar.weixin.common.bean.WxJsapiSignature;
 import me.chanjar.weixin.common.bean.result.WxError;
 import me.chanjar.weixin.common.bean.result.WxMediaUploadResult;
 import me.chanjar.weixin.common.exception.WxErrorException;
 import me.chanjar.weixin.common.session.StandardSessionManager;
 import me.chanjar.weixin.common.session.WxSessionManager;
+import me.chanjar.weixin.common.util.RandomUtils;
 import me.chanjar.weixin.common.util.StringUtils;
 import me.chanjar.weixin.common.util.crypto.SHA1;
 import me.chanjar.weixin.common.util.fs.FileUtils;
@@ -42,14 +44,9 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 public class WxMpServiceImpl implements WxMpService {
-
-  protected final String RANDOM_STR = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-
-  protected final Random RANDOM = new Random();
 
   protected final Logger log = LoggerFactory.getLogger(WxMpServiceImpl.class);
 
@@ -148,9 +145,9 @@ public class WxMpServiceImpl implements WxMpService {
     return wxMpConfigStorage.getJsapiTicket();
   }
 
-  public WxMpJsapiSignature createJsapiSignature(String url) throws WxErrorException {
+  public WxJsapiSignature createJsapiSignature(String url) throws WxErrorException {
     long timestamp = System.currentTimeMillis() / 1000;
-    String noncestr = getRandomStr();
+    String noncestr = RandomUtils.getRandomStr();
     String jsapiTicket = getJsapiTicket(false);
     try {
       String signature = SHA1.genWithAmple(
@@ -159,7 +156,7 @@ public class WxMpServiceImpl implements WxMpService {
           "timestamp=" + timestamp,
           "url=" + url
       );
-      WxMpJsapiSignature jsapiSignature = new WxMpJsapiSignature();
+      WxJsapiSignature jsapiSignature = new WxJsapiSignature();
       jsapiSignature.setTimestamp(timestamp);
       jsapiSignature.setNoncestr(noncestr);
       jsapiSignature.setUrl(url);
@@ -168,14 +165,6 @@ public class WxMpServiceImpl implements WxMpService {
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  protected String getRandomStr() {
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < 16; i++) {
-      sb.append(RANDOM_STR.charAt(RANDOM.nextInt(RANDOM_STR.length())));
-    }
-    return sb.toString();
   }
 
   public void customMessageSend(WxMpCustomMessage message) throws WxErrorException {

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.security.NoSuchAlgorithmException;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -463,6 +464,29 @@ public class WxMpServiceImpl implements WxMpService {
       ipArray[i] = ipList.get(i).getAsString();
     }
     return ipArray;
+  }
+
+
+  @Override
+  public List<WxMpUserSummary> getUserSummary(Date beginDate, Date endDate) throws WxErrorException {
+    String url = "https://api.weixin.qq.com/datacube/getusersummary";
+    JsonObject param = new JsonObject();
+    param.addProperty("begin_date", SIMPLE_DATE_FORMAT.format(beginDate));
+    param.addProperty("end_date", SIMPLE_DATE_FORMAT.format(endDate));
+    String responseContent = post(url, param.toString());
+    JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
+    return WxMpGsonBuilder.INSTANCE.create().fromJson(tmpJsonElement.getAsJsonObject().get("list"), new TypeToken<List<WxMpUserSummary>>(){}.getType());
+  }
+
+  @Override
+  public List<WxMpUserCumulate> getUserCumulate(Date beginDate, Date endDate) throws WxErrorException {
+    String url = "https://api.weixin.qq.com/datacube/getusercumulate";
+    JsonObject param = new JsonObject();
+    param.addProperty("begin_date", SIMPLE_DATE_FORMAT.format(beginDate));
+    param.addProperty("end_date", SIMPLE_DATE_FORMAT.format(endDate));
+    String responseContent = post(url, param.toString());
+    JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
+    return WxMpGsonBuilder.INSTANCE.create().fromJson(tmpJsonElement.getAsJsonObject().get("list"), new TypeToken<List<WxMpUserCumulate>>(){}.getType());
   }
 
   public String get(String url, String queryParam) throws WxErrorException {

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -435,7 +435,7 @@ public class WxMpServiceImpl implements WxMpService {
   @Override
   public boolean oauth2validateAccessToken(WxMpOAuth2AccessToken oAuth2AccessToken) {
     String url = "https://api.weixin.qq.com/sns/auth?";
-    url += "access_token=" + oAuth2AccessToken;
+    url += "access_token=" + oAuth2AccessToken.getAccessToken();
     url += "&openid=" + oAuth2AccessToken.getOpenId();
 
     try {

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -1,5 +1,6 @@
 package me.chanjar.weixin.mp.api;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.internal.Streams;
@@ -449,6 +450,19 @@ public class WxMpServiceImpl implements WxMpService {
       return false;
     }
     return true;
+  }
+
+  @Override
+  public String[] getCallbackIP() throws WxErrorException {
+    String url = "https://api.weixin.qq.com/cgi-bin/getcallbackip";
+    String responseContent = get(url, null);
+    JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
+    JsonArray ipList = tmpJsonElement.getAsJsonObject().get("ip_list").getAsJsonArray();
+    String[] ipArray = new String[ipList.size()];
+    for (int i = 0; i < ipList.size(); i++) {
+      ipArray[i] = ipList.get(i).getAsString();
+    }
+    return ipArray;
   }
 
   public String get(String url, String queryParam) throws WxErrorException {

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpCustomMessage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpCustomMessage.java
@@ -3,6 +3,7 @@ package me.chanjar.weixin.mp.bean;
 import me.chanjar.weixin.mp.bean.custombuilder.*;
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,7 +12,7 @@ import java.util.List;
  * @author chanjarster
  *
  */
-public class WxMpCustomMessage {
+public class WxMpCustomMessage implements Serializable {
 
   private String toUser;
   private String msgType;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpGroup.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpGroup.java
@@ -2,12 +2,14 @@ package me.chanjar.weixin.mp.bean;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * 微信用户分组
  * @author chanjarster
  *
  */
-public class WxMpGroup {
+public class WxMpGroup implements Serializable {
 
   private long id = -1;
   private String name;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpMassGroupMessage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpMassGroupMessage.java
@@ -2,12 +2,14 @@ package me.chanjar.weixin.mp.bean;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * 分组群发的消息
  * 
  * @author chanjarster
  */
-public class WxMpMassGroupMessage {
+public class WxMpMassGroupMessage implements Serializable {
   
   private Long groupId;
   private String msgtype;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpMassNews.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpMassNews.java
@@ -2,6 +2,7 @@ package me.chanjar.weixin.mp.bean;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,7 +11,7 @@ import java.util.List;
  * @author chanjarster
  *
  */
-public class WxMpMassNews {
+public class WxMpMassNews implements Serializable {
 
   private List<WxMpMassNewsArticle> articles = new ArrayList<WxMpMassNewsArticle>();
   

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpMassOpenIdsMessage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpMassOpenIdsMessage.java
@@ -2,6 +2,7 @@ package me.chanjar.weixin.mp.bean;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,7 +11,7 @@ import java.util.List;
  * 
  * @author chanjarster
  */
-public class WxMpMassOpenIdsMessage {
+public class WxMpMassOpenIdsMessage implements Serializable {
   
   private List<String> toUsers = new ArrayList<String>();
   private String msgType;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpMassVideo.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpMassVideo.java
@@ -2,12 +2,14 @@ package me.chanjar.weixin.mp.bean;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * 群发时用到的视频素材
  * 
  * @author chanjarster
  */
-public class WxMpMassVideo {
+public class WxMpMassVideo implements Serializable {
 
   private String mediaId;
   private String title;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpSemanticQuery.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpSemanticQuery.java
@@ -2,6 +2,8 @@ package me.chanjar.weixin.mp.bean;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * 语义理解查询用对象
  *
@@ -9,7 +11,7 @@ import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
  *
  * @author Daniel Qian
  */
-public class WxMpSemanticQuery {
+public class WxMpSemanticQuery implements Serializable {
 
   private String query;
   private String category;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpTemplateData.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpTemplateData.java
@@ -1,9 +1,11 @@
 package me.chanjar.weixin.mp.bean;
 
+import java.io.Serializable;
+
 /**
  * @author Daniel Qian
  */
-public class WxMpTemplateData {
+public class WxMpTemplateData implements Serializable {
 
   private String name;
   private String value;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpTemplateMessage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpTemplateMessage.java
@@ -2,10 +2,11 @@ package me.chanjar.weixin.mp.bean;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class WxMpTemplateMessage {
+public class WxMpTemplateMessage implements Serializable {
 
   private String toUser;
   private String templateId;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlMessage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlMessage.java
@@ -10,6 +10,7 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +26,7 @@ import java.util.List;
  * @author chanjarster
  */
 @XStreamAlias("xml")
-public class WxMpXmlMessage {
+public class WxMpXmlMessage implements Serializable {
 
   ///////////////////////
   // 以下都是微信推送过来的消息的xml的element所对应的属性

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlOutMessage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlOutMessage.java
@@ -8,8 +8,10 @@ import me.chanjar.weixin.mp.bean.outxmlbuilder.*;
 import me.chanjar.weixin.mp.util.crypto.WxMpCryptUtil;
 import me.chanjar.weixin.mp.util.xml.XStreamTransformer;
 
+import java.io.Serializable;
+
 @XStreamAlias("xml")
-public abstract class WxMpXmlOutMessage {
+public abstract class WxMpXmlOutMessage implements Serializable {
 
   @XStreamAlias("ToUserName")
   @XStreamConverter(value=XStreamCDataConverter.class)

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpMassSendResult.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpMassSendResult.java
@@ -2,6 +2,8 @@ package me.chanjar.weixin.mp.bean.result;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * <pre>
  * 群发消息一发送就返回的结果
@@ -13,7 +15,7 @@ import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
  * @author chanjarster
  *
  */
-public class WxMpMassSendResult {
+public class WxMpMassSendResult implements Serializable {
 
   private String errorCode;
   private String errorMsg;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpMassUploadResult.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpMassUploadResult.java
@@ -2,6 +2,8 @@ package me.chanjar.weixin.mp.bean.result;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * <pre>
  * 上传群发用的素材的结果
@@ -10,7 +12,7 @@ import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
  * @author chanjarster
  *
  */
-public class WxMpMassUploadResult {
+public class WxMpMassUploadResult implements Serializable {
 
   private String type;
   private String mediaId;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpOAuth2AccessToken.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpOAuth2AccessToken.java
@@ -2,7 +2,9 @@ package me.chanjar.weixin.mp.bean.result;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
-public class WxMpOAuth2AccessToken {
+import java.io.Serializable;
+
+public class WxMpOAuth2AccessToken implements Serializable {
 
   private String accessToken;
 

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpQrCodeTicket.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpQrCodeTicket.java
@@ -2,12 +2,14 @@ package me.chanjar.weixin.mp.bean.result;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * 换取二维码的Ticket
  * 
  * @author chanjarster
  */
-public class WxMpQrCodeTicket {
+public class WxMpQrCodeTicket implements Serializable {
   
   protected String ticket;
   protected int expire_seconds = -1;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpSemanticQueryResult.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpSemanticQueryResult.java
@@ -2,6 +2,8 @@ package me.chanjar.weixin.mp.bean.result;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * 语义理解查询结果对象
  *
@@ -9,7 +11,7 @@ import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
  *
  * @author Daniel Qian
  */
-public class WxMpSemanticQueryResult {
+public class WxMpSemanticQueryResult implements Serializable {
 
   private String query;
   private String type;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpUser.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpUser.java
@@ -20,7 +20,11 @@ public class WxMpUser {
   protected String headImgUrl;
   protected Long subscribeTime;
   protected String unionId;
-  
+  protected Integer sexId;
+
+  public Boolean getSubscribe() {
+    return subscribe;
+  }
   public Boolean isSubscribe() {
     return subscribe;
   }
@@ -87,7 +91,16 @@ public class WxMpUser {
   public void setUnionId(String unionId) {
     this.unionId = unionId;
   }
-  
+
+  public Integer getSexId() {
+
+    return sexId;
+  }
+
+  public void setSexId(Integer sexId) {
+    this.sexId = sexId;
+  }
+
   public static WxMpUser fromJson(String json) {
     return WxMpGsonBuilder.INSTANCE.create().fromJson(json, WxMpUser.class);
   }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpUser.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpUser.java
@@ -2,12 +2,14 @@ package me.chanjar.weixin.mp.bean.result;
 
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
 
+import java.io.Serializable;
+
 /**
  * 微信用户信息
  * @author chanjarster
  *
  */
-public class WxMpUser {
+public class WxMpUser implements Serializable {
 
   protected Boolean subscribe;
   protected String openId;

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpUserCumulate.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpUserCumulate.java
@@ -1,0 +1,41 @@
+package me.chanjar.weixin.mp.bean.result;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * <pre>
+ * 累计用户数据接口的返回JSON数据包
+ * http://mp.weixin.qq.com/wiki/3/ecfed6e1a0a03b5f35e5efac98e864b7.html
+ * </pre>
+ */
+public class WxMpUserCumulate implements Serializable {
+
+  private Date refDate;
+
+  private Integer cumulateUser;
+
+  public Date getRefDate() {
+    return refDate;
+  }
+
+  public void setRefDate(Date refDate) {
+    this.refDate = refDate;
+  }
+
+  public Integer getCumulateUser() {
+    return cumulateUser;
+  }
+
+  public void setCumulateUser(Integer cumulateUser) {
+    this.cumulateUser = cumulateUser;
+  }
+
+  @Override
+  public String toString() {
+    return "WxMpUserCumulate{" +
+        "refDate=" + refDate +
+        ", cumulateUser=" + cumulateUser +
+        '}';
+  }
+}

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpUserSummary.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpUserSummary.java
@@ -1,0 +1,63 @@
+package me.chanjar.weixin.mp.bean.result;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * <pre>
+ * 用户增减数据接口的返回JSON数据包
+ * http://mp.weixin.qq.com/wiki/3/ecfed6e1a0a03b5f35e5efac98e864b7.html
+ * </pre>
+ */
+public class WxMpUserSummary implements Serializable {
+
+  private Date refDate;
+
+  private Integer userSource;
+
+  private Integer newUser;
+
+  private Integer cancelUser;
+
+  public Date getRefDate() {
+    return refDate;
+  }
+
+  public void setRefDate(Date refDate) {
+    this.refDate = refDate;
+  }
+
+  public Integer getUserSource() {
+    return userSource;
+  }
+
+  public void setUserSource(Integer userSource) {
+    this.userSource = userSource;
+  }
+
+  public Integer getNewUser() {
+    return newUser;
+  }
+
+  public void setNewUser(Integer newUser) {
+    this.newUser = newUser;
+  }
+
+  public Integer getCancelUser() {
+    return cancelUser;
+  }
+
+  public void setCancelUser(Integer cancelUser) {
+    this.cancelUser = cancelUser;
+  }
+
+  @Override
+  public String toString() {
+    return "WxMpUserSummary{" +
+        "refDate=" + refDate +
+        ", userSource=" + userSource +
+        ", newUser=" + newUser +
+        ", cancelUser=" + cancelUser +
+        '}';
+  }
+}

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpGsonBuilder.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpGsonBuilder.java
@@ -25,6 +25,8 @@ public class WxMpGsonBuilder {
     INSTANCE.registerTypeAdapter(WxMpTemplateMessage.class, new WxMpTemplateMessageGsonAdapter());
     INSTANCE.registerTypeAdapter(WxMpSemanticQueryResult.class, new WxMpSemanticQueryResultAdapter());
     INSTANCE.registerTypeAdapter(WxMpOAuth2AccessToken.class, new WxMpOAuth2AccessTokenAdapter());
+    INSTANCE.registerTypeAdapter(WxMpUserSummary.class, new WxMpUserSummaryGsonAdapter());
+    INSTANCE.registerTypeAdapter(WxMpUserCumulate.class, new WxMpUserCumulateGsonAdapter());
   }
   
   public static Gson create() {

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpGsonBuilder.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpGsonBuilder.java
@@ -16,7 +16,7 @@ public class WxMpGsonBuilder {
     INSTANCE.registerTypeAdapter(WxMpMassGroupMessage.class, new WxMpMassGroupMessageGsonAdapter());
     INSTANCE.registerTypeAdapter(WxMpMassOpenIdsMessage.class, new WxMpMassOpenIdsMessageGsonAdapter());
     INSTANCE.registerTypeAdapter(WxMpGroup.class, new WxMpGroupGsonAdapter());
-    INSTANCE.registerTypeAdapter(WxMpUser.class, new WxUserGsonAdapter());
+    INSTANCE.registerTypeAdapter(WxMpUser.class, new WxMpUserGsonAdapter());
     INSTANCE.registerTypeAdapter(WxMpUserList.class, new WxUserListGsonAdapter());
     INSTANCE.registerTypeAdapter(WxMpMassVideo.class, new WxMpMassVideoAdapter());
     INSTANCE.registerTypeAdapter(WxMpMassSendResult.class, new WxMpMassSendResultAdapter());

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpUserCumulateGsonAdapter.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpUserCumulateGsonAdapter.java
@@ -1,0 +1,47 @@
+/*
+ * KINGSTAR MEDIA SOLUTIONS Co.,LTD. Copyright c 2005-2013. All rights reserved.
+ *
+ * This source code is the property of KINGSTAR MEDIA SOLUTIONS LTD. It is intended
+ * only for the use of KINGSTAR MEDIA application development. Reengineering, reproduction
+ * arose from modification of the original source, or other redistribution of this source
+ * is not permitted without written permission of the KINGSTAR MEDIA SOLUTIONS LTD.
+ */
+package me.chanjar.weixin.mp.util.json;
+
+import com.google.gson.*;
+import me.chanjar.weixin.common.util.json.GsonHelper;
+import me.chanjar.weixin.mp.bean.result.WxMpMassUploadResult;
+import me.chanjar.weixin.mp.bean.result.WxMpUserCumulate;
+import me.chanjar.weixin.mp.bean.result.WxMpUserSummary;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+/**
+ * 
+ * @author Daniel Qian
+ *
+ */
+public class WxMpUserCumulateGsonAdapter implements JsonDeserializer<WxMpUserCumulate> {
+
+  private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+  public WxMpUserCumulate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    WxMpUserCumulate cumulate = new WxMpUserCumulate();
+    JsonObject summaryJsonObject = json.getAsJsonObject();
+
+    try {
+      String refDate = GsonHelper.getString(summaryJsonObject, "ref_date");
+      if (refDate != null) {
+        cumulate.setRefDate(SIMPLE_DATE_FORMAT.parse(refDate));
+      }
+      cumulate.setCumulateUser(GsonHelper.getInteger(summaryJsonObject, "cumulate_user"));
+    } catch (ParseException e) {
+      throw new JsonParseException(e);
+    }
+    return cumulate;
+
+  }
+  
+}

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpUserGsonAdapter.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpUserGsonAdapter.java
@@ -14,7 +14,7 @@ import me.chanjar.weixin.mp.bean.result.WxMpUser;
 
 import java.lang.reflect.Type;
 
-public class WxUserGsonAdapter implements JsonDeserializer<WxMpUser> {
+public class WxMpUserGsonAdapter implements JsonDeserializer<WxMpUser> {
 
   public WxMpUser deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
     JsonObject o = json.getAsJsonObject();
@@ -29,10 +29,11 @@ public class WxUserGsonAdapter implements JsonDeserializer<WxMpUser> {
     wxMpUser.setProvince(GsonHelper.getString(o, "province"));
     wxMpUser.setSubscribeTime(GsonHelper.getLong(o, "subscribe_time"));
     wxMpUser.setUnionId(GsonHelper.getString(o, "unionid"));
-    Integer sex = GsonHelper.getInteger(o, "sex");
-    if(new Integer(1).equals(sex)) {
+    Integer sexId = GsonHelper.getInteger(o, "sex");
+    wxMpUser.setSexId(sexId);
+    if(new Integer(1).equals(sexId)) {
       wxMpUser.setSex("男");
-    } else if (new Integer(2).equals(sex)) {
+    } else if (new Integer(2).equals(sexId)) {
       wxMpUser.setSex("女");
     } else {
       wxMpUser.setSex("未知");

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpUserSummaryGsonAdapter.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpUserSummaryGsonAdapter.java
@@ -1,0 +1,47 @@
+/*
+ * KINGSTAR MEDIA SOLUTIONS Co.,LTD. Copyright c 2005-2013. All rights reserved.
+ *
+ * This source code is the property of KINGSTAR MEDIA SOLUTIONS LTD. It is intended
+ * only for the use of KINGSTAR MEDIA application development. Reengineering, reproduction
+ * arose from modification of the original source, or other redistribution of this source
+ * is not permitted without written permission of the KINGSTAR MEDIA SOLUTIONS LTD.
+ */
+package me.chanjar.weixin.mp.util.json;
+
+import com.google.gson.*;
+import me.chanjar.weixin.common.util.json.GsonHelper;
+import me.chanjar.weixin.mp.bean.result.WxMpMassUploadResult;
+import me.chanjar.weixin.mp.bean.result.WxMpUserSummary;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+/**
+ * @author Daniel Qian
+ */
+public class WxMpUserSummaryGsonAdapter implements JsonDeserializer<WxMpUserSummary> {
+
+  private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+  public WxMpUserSummary deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    WxMpUserSummary summary = new WxMpUserSummary();
+    JsonObject summaryJsonObject = json.getAsJsonObject();
+
+    try {
+      String refDate = GsonHelper.getString(summaryJsonObject, "ref_date");
+      if (refDate != null) {
+        summary.setRefDate(SIMPLE_DATE_FORMAT.parse(refDate));
+      }
+      summary.setUserSource(GsonHelper.getInteger(summaryJsonObject, "user_source"));
+      summary.setNewUser(GsonHelper.getInteger(summaryJsonObject, "new_user"));
+      summary.setCancelUser(GsonHelper.getInteger(summaryJsonObject, "cancel_user"));
+    } catch (ParseException e) {
+      throw new JsonParseException(e);
+    }
+
+    return summary;
+  }
+
+}

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxUserListGsonAdapter.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxUserListGsonAdapter.java
@@ -22,9 +22,11 @@ public class WxUserListGsonAdapter implements JsonDeserializer<WxMpUserList> {
     wxMpUserList.setTotal(GsonHelper.getInteger(o, "total"));
     wxMpUserList.setCount(GsonHelper.getInteger(o, "count"));
     wxMpUserList.setNextOpenId(GsonHelper.getString(o, "next_openid"));
-    JsonArray data = o.get("data").getAsJsonObject().get("openid").getAsJsonArray();
-    for (int i = 0; i < data.size(); i++) {
-      wxMpUserList.getOpenIds().add(GsonHelper.getAsString(data.get(i)));
+    if (!o.get("data").isJsonNull() && !o.get("data").getAsJsonObject().get("openid").isJsonNull()) {
+      JsonArray data = o.get("data").getAsJsonObject().get("openid").getAsJsonArray();
+      for (int i = 0; i < data.size(); i++) {
+        wxMpUserList.getOpenIds().add(GsonHelper.getAsString(data.get(i)));
+      }
     }
     return wxMpUserList;
   }

--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/WxMpMiscAPITest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/WxMpMiscAPITest.java
@@ -4,12 +4,15 @@ import com.google.inject.Inject;
 import me.chanjar.weixin.common.api.WxConsts;
 import me.chanjar.weixin.common.bean.result.WxMediaUploadResult;
 import me.chanjar.weixin.common.exception.WxErrorException;
+import me.chanjar.weixin.common.session.WxSession;
 import me.chanjar.weixin.mp.bean.WxMpMassGroupMessage;
 import me.chanjar.weixin.mp.bean.WxMpMassNews;
 import me.chanjar.weixin.mp.bean.WxMpMassOpenIdsMessage;
 import me.chanjar.weixin.mp.bean.WxMpMassVideo;
 import me.chanjar.weixin.mp.bean.result.WxMpMassSendResult;
 import me.chanjar.weixin.mp.bean.result.WxMpMassUploadResult;
+import me.chanjar.weixin.mp.bean.result.WxMpUserCumulate;
+import me.chanjar.weixin.mp.bean.result.WxMpUserSummary;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Guice;
@@ -17,7 +20,11 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 
 /**
  *
@@ -32,11 +39,31 @@ public class WxMpMiscAPITest {
   protected WxMpServiceImpl wxService;
 
   @Test
-  public void getCallbackIP() throws WxErrorException {
+  public void testGetCallbackIP() throws WxErrorException {
     String[] ipArray = wxService.getCallbackIP();
     System.out.println(Arrays.toString(ipArray));
     Assert.assertNotNull(ipArray);
     Assert.assertNotEquals(ipArray.length, 0);
+  }
+
+  @Test
+  public void testGetUserSummary() throws WxErrorException, ParseException {
+    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    Date beginDate = simpleDateFormat.parse("2015-01-01");
+    Date endDate = simpleDateFormat.parse("2015-01-02");
+    List<WxMpUserSummary> summaries = wxService.getUserSummary(beginDate, endDate);
+    System.out.println(summaries);
+    Assert.assertNotNull(summaries);
+  }
+
+  @Test
+  public void testGetUserCumulate() throws WxErrorException, ParseException {
+    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    Date beginDate = simpleDateFormat.parse("2015-01-01");
+    Date endDate = simpleDateFormat.parse("2015-01-02");
+    List<WxMpUserCumulate> cumulates =  wxService.getUserCumulate(beginDate, endDate);
+    System.out.println(cumulates);
+    Assert.assertNotNull(cumulates);
   }
 
 }

--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/WxMpMiscAPITest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/WxMpMiscAPITest.java
@@ -1,0 +1,42 @@
+package me.chanjar.weixin.mp.api;
+
+import com.google.inject.Inject;
+import me.chanjar.weixin.common.api.WxConsts;
+import me.chanjar.weixin.common.bean.result.WxMediaUploadResult;
+import me.chanjar.weixin.common.exception.WxErrorException;
+import me.chanjar.weixin.mp.bean.WxMpMassGroupMessage;
+import me.chanjar.weixin.mp.bean.WxMpMassNews;
+import me.chanjar.weixin.mp.bean.WxMpMassOpenIdsMessage;
+import me.chanjar.weixin.mp.bean.WxMpMassVideo;
+import me.chanjar.weixin.mp.bean.result.WxMpMassSendResult;
+import me.chanjar.weixin.mp.bean.result.WxMpMassUploadResult;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ *
+ * @author chanjarster
+ *
+ */
+@Test(groups = "miscAPI", dependsOnGroups = { "baseAPI"})
+@Guice(modules = ApiTestModule.class)
+public class WxMpMiscAPITest {
+
+  @Inject
+  protected WxMpServiceImpl wxService;
+
+  @Test
+  public void getCallbackIP() throws WxErrorException {
+    String[] ipArray = wxService.getCallbackIP();
+    System.out.println(Arrays.toString(ipArray));
+    Assert.assertNotNull(ipArray);
+    Assert.assertNotEquals(ipArray.length, 0);
+  }
+
+}

--- a/weixin-java-mp/src/test/resources/testng.xml
+++ b/weixin-java-mp/src/test/resources/testng.xml
@@ -15,6 +15,7 @@
 			<class name="me.chanjar.weixin.mp.api.WxMpShortUrlAPITest" />
 			<class name="me.chanjar.weixin.mp.api.WxMpMessageRouterTest" />
       <class name="me.chanjar.weixin.mp.api.WxMpJsAPITest" />
+      <class name="me.chanjar.weixin.mp.api.WxMpMiscAPITest" />
 		</classes>
 	</test>
 


### PR DESCRIPTION
hanjarster：

　　您好：

　　在weixin-java-tools的基础上对微信消息回复进行了扩展，增加了事件推送，具体做法如下：
　　当用户点击某一个菜单，路由（WxMpMessageRouter）截获点击事件，然后根据微信API返回如下信息：
<xml>
    <ToUserName><![CDATA[gh_832a39344845]]></ToUserName>
    <FromUserName><![CDATA[o3Hw_s5DhRRP19M3PIrXqlnul6u4]]></FromUserName>
    <CreateTime>1423187088</CreateTime>
    <MsgType><![CDATA[event]]></MsgType>
    <Event><![CDATA[VIEW]]></Event>
    <EventKey><![CDATA[mpweixin.ngrok.com/bizcard/contacts?openid=o3Hw_s5DhRRP19M3PIrXqlnul6u4]]></EventKey>
</xml>

该做法的目的是获取用户的openid然后跳转到指定连接地址，但是经测试无法完成事件响应，完成链接跳转。