### PR TITLE
Improve 'templateSend' method to check the response code to see if it…

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -507,7 +507,10 @@ public class WxMpServiceImpl implements WxMpService {
     String url = "https://api.weixin.qq.com/cgi-bin/message/template/send";
     String responseContent = execute(new SimplePostRequestExecutor(), url, templateMessage.toJson());
     JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
-    return tmpJsonElement.getAsJsonObject().get("msgid").getAsString();
+    final JsonObject jsonObject = tmpJsonElement.getAsJsonObject();
+    if (jsonObject.get("errcode").getAsInt() == 0)
+      return jsonObject.get("msgid").getAsString();
+    throw new WxErrorException(WxError.fromJson(responseContent));
   }
 
   public WxMpSemanticQueryResult semanticQuery(WxMpSemanticQuery semanticQuery) throws WxErrorException {


### PR DESCRIPTION
在review线上的数据时候，发现有**msgid为0**的情况。

我估计当时`templateSend`调用微信API发送失败了，但是该函数并未检查API返回的`errcode`值来判断调用是否成功。

增加了代码检查返回值，如果失败，扔出异常。