### PR TITLE
企业号的发送消息接口的数据格式中加入safe字段

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/api/WxConsts.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/api/WxConsts.java
@@ -30,6 +30,8 @@ public class WxConsts {
   public static final String CUSTOM_MSG_NEWS = "news";
   public static final String CUSTOM_MSG_FILE = "file";
   public static final String CUSTOM_MSG_TRANSFER_CUSTOMER_SERVICE = "transfer_customer_service";
+  public static final String CUSTOM_MSG_SAFE_NO = "0";
+  public static final String CUSTOM_MSG_SAFE_YES = "1";
   
   ///////////////////////
   // 群发消息的消息类型

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpMessage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpMessage.java
@@ -26,6 +26,7 @@ public class WxCpMessage implements Serializable {
   private String description;
   private String musicUrl;
   private String hqMusicUrl;
+  private String safe;
   private List<WxArticle> articles = new ArrayList<WxArticle>();
   
   public String getToUser() {
@@ -63,6 +64,14 @@ public class WxCpMessage implements Serializable {
     return msgType;
   }
   
+  public String getSafe() {
+    return safe;
+  }
+
+  public void setSafe(String safe) {
+    this.safe = safe;
+  }
+
   /**
    * <pre>
    * 请使用

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/messagebuilder/BaseBuilder.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/messagebuilder/BaseBuilder.java
@@ -1,5 +1,6 @@
 package me.chanjar.weixin.cp.bean.messagebuilder;
 
+import me.chanjar.weixin.common.api.WxConsts;
 import me.chanjar.weixin.cp.bean.WxCpMessage;
 
 public class BaseBuilder<T> {
@@ -8,6 +9,7 @@ public class BaseBuilder<T> {
   protected String toUser;
   protected String toParty;
   protected String toTag;
+  protected String safe;
 
   public T agentId(String agentId) {
     this.agentId = agentId;
@@ -29,6 +31,11 @@ public class BaseBuilder<T> {
     return (T) this;
   }
 
+  public T safe(String safe) {
+    this.safe = safe;
+    return (T) this;
+  }
+
   public WxCpMessage build() {
     WxCpMessage m = new WxCpMessage();
     m.setAgentId(this.agentId);
@@ -36,6 +43,8 @@ public class BaseBuilder<T> {
     m.setToUser(this.toUser);
     m.setToParty(this.toParty);
     m.setToTag(this.toTag);
+    m.setSafe(
+      (this.safe == null || "".equals(this.safe))? WxConsts.CUSTOM_MSG_SAFE_NO: this.safe);
     return m;
   }
 


### PR DESCRIPTION
根据微信企业号官方文档（
http://qydev.weixin.qq.com/wiki/index.php?title=%E6%B6%88%E6%81%AF%E7%B1%BB%E5%9E%8B%E5%8F%8A%E6%95%B0%E6%8D%AE%E6%A0%BC%E5%BC%8F
），发送消息接口的数据格式中需要加入safe字段。并且经过实际验证，官方文档上“safe为非必须项”的表述有误，safe应为必须项，即如果参数中没有写safe字段而调用发送消息接口的话，微信服务器会正常返回，但touser却收不到任何消息。

Change-Id: Ifc894e6f6b03147f000b42f346d2bdccb11b0c64
Signed-off-by: Liu Kai <liukai@tinkers.com.cn>