### PR TITLE
XStreamTransformer 增加注册方法,来注册自定义的消息类型

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/xml/XStreamTransformer.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/xml/XStreamTransformer.java
@@ -32,6 +32,15 @@ public class XStreamTransformer {
   }
 
   /**
+   * 注册扩展消息的解析器
+   * @param clz 类型
+   * @param xStream xml解析器
+     */
+  public static void register(Class clz,XStream xStream){
+    CLASS_2_XSTREAM_INSTANCE.put(clz,xStream);
+  }
+
+  /**
    * pojo -> xml
    *
    * @param clazz

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/xml/XStreamTransformer.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/xml/XStreamTransformer.java
@@ -32,6 +32,16 @@ public class XStreamTransformer {
   }
 
   /**
+   * 注册扩展消息的解析器
+   * @param clz 类型
+   * @param xStream xml解析器
+   */
+  public static void register(Class clz,XStream xStream){
+    CLASS_2_XSTREAM_INSTANCE.put(clz,xStream);
+  }
+
+
+  /**
    * pojo -> xml
    *
    * @param clazz


### PR DESCRIPTION
工具包内的多客服消息转发只能制定具体客服，微信还提供了不指定的转发方式。发现XStreamTransformer无法扩展新的消息类型因此添加了注册方法。 