### PR TITLE
XStreamTransformer 增加注册方法,来注册自定义的消息类型

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/xml/XStreamTransformer.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/xml/XStreamTransformer.java
@@ -32,6 +32,15 @@ public class XStreamTransformer {
   }
 
   /**
+   * 注册扩展消息的解析器
+   * @param clz 类型
+   * @param xStream xml解析器
+     */
+  public static void register(Class clz,XStream xStream){
+    CLASS_2_XSTREAM_INSTANCE.put(clz,xStream);
+  }
+
+  /**
    * pojo -> xml
    *
    * @param clazz

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlOutTransferCustomerServiceMessage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlOutTransferCustomerServiceMessage.java
@@ -4,23 +4,22 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import me.chanjar.weixin.common.api.WxConsts;
 import me.chanjar.weixin.common.util.xml.XStreamCDataConverter;
-import me.chanjar.weixin.common.util.xml.XStreamMediaIdConverter;
 
 @XStreamAlias("xml")
 public class WxMpXmlOutTransferCustomerServiceMessage extends WxMpXmlOutMessage {
   @XStreamAlias("TransInfo")
-  protected final TransInfo transInfo = new TransInfo();
+  protected TransInfo transInfo;
 
   public WxMpXmlOutTransferCustomerServiceMessage() {
     this.msgType = WxConsts.CUSTOM_MSG_TRANSFER_CUSTOMER_SERVICE;
   }
 
-  public String getKfAccount() {
-    return transInfo.getKfAccount();
+  public TransInfo getTransInfo() {
+    return transInfo;
   }
 
-  public void setKfAccount(String kfAccount) {
-    transInfo.setKfAccount(kfAccount);
+  public void setTransInfo(TransInfo transInfo) {
+    this.transInfo = transInfo;
   }
 
   @XStreamAlias("TransInfo")

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/outxmlbuilder/TransferCustomerServiceBuilder.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/outxmlbuilder/TransferCustomerServiceBuilder.java
@@ -1,5 +1,6 @@
 package me.chanjar.weixin.mp.bean.outxmlbuilder;
 
+import me.chanjar.weixin.common.util.StringUtils;
 import me.chanjar.weixin.mp.bean.WxMpXmlOutTransferCustomerServiceMessage;
 
 /**
@@ -22,7 +23,11 @@ public final class TransferCustomerServiceBuilder extends BaseBuilder<TransferCu
   public WxMpXmlOutTransferCustomerServiceMessage build() {
     WxMpXmlOutTransferCustomerServiceMessage m = new WxMpXmlOutTransferCustomerServiceMessage();
     setCommon(m);
-    m.setKfAccount(kfAccount);
+    if(StringUtils.isNotBlank(kfAccount)){
+      WxMpXmlOutTransferCustomerServiceMessage.TransInfo transInfo = new WxMpXmlOutTransferCustomerServiceMessage.TransInfo();
+      transInfo.setKfAccount(kfAccount);
+      m.setTransInfo(transInfo);
+    }
     return m;
   }
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/xml/XStreamTransformer.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/xml/XStreamTransformer.java
@@ -32,6 +32,16 @@ public class XStreamTransformer {
   }
 
   /**
+   * 注册扩展消息的解析器
+   * @param clz 类型
+   * @param xStream xml解析器
+   */
+  public static void register(Class clz,XStream xStream){
+    CLASS_2_XSTREAM_INSTANCE.put(clz,xStream);
+  }
+
+
+  /**
    * pojo -> xml
    *
    * @param clazz

--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/bean/WxMpXmlOutTransferCustomerServiceMessageTest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/bean/WxMpXmlOutTransferCustomerServiceMessageTest.java
@@ -1,0 +1,70 @@
+package me.chanjar.weixin.mp.bean;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Created by ben on 2015/12/29.
+ */
+public class WxMpXmlOutTransferCustomerServiceMessageTest {
+  @Test
+  public void test() {
+    WxMpXmlOutTransferCustomerServiceMessage m = new WxMpXmlOutTransferCustomerServiceMessage();
+    m.setCreateTime(1399197672L);
+    m.setFromUserName("fromuser");
+    m.setToUserName("touser");
+
+    String expected = "<xml>" +
+      "<ToUserName><![CDATA[touser]]></ToUserName>" +
+      "<FromUserName><![CDATA[fromuser]]></FromUserName>" +
+      "<CreateTime>1399197672</CreateTime>" +
+      "<MsgType><![CDATA[transfer_customer_service]]></MsgType>" +
+      "</xml>";
+    System.out.println(m.toXml());
+    Assert.assertEquals(m.toXml().replaceAll("\\s", ""), expected.replaceAll("\\s", ""));
+
+    expected = " <xml>" +
+      "<ToUserName><![CDATA[touser]]></ToUserName>" +
+      "<FromUserName><![CDATA[fromuser]]></FromUserName>" +
+      "<CreateTime>1399197672</CreateTime>" +
+      "<MsgType><![CDATA[transfer_customer_service]]></MsgType>" +
+      "<TransInfo>" +
+      "<KfAccount><![CDATA[test1@test]]></KfAccount>" +
+      "</TransInfo>" +
+      "</xml>";
+    WxMpXmlOutTransferCustomerServiceMessage.TransInfo transInfo = new WxMpXmlOutTransferCustomerServiceMessage.TransInfo();
+    transInfo.setKfAccount("test1@test");
+    m.setTransInfo(transInfo);
+    System.out.println(m.toXml());
+    Assert.assertEquals(m.toXml().replaceAll("\\s", ""), expected.replaceAll("\\s", ""));
+  }
+
+  @Test
+  public void testBuild() {
+    WxMpXmlOutTransferCustomerServiceMessage m = WxMpXmlOutMessage.TRANSFER_CUSTOMER_SERVICE().fromUser("fromuser").toUser("touser").build();
+    m.setCreateTime(1399197672L);
+    String expected = "<xml>" +
+      "<ToUserName><![CDATA[touser]]></ToUserName>" +
+      "<FromUserName><![CDATA[fromuser]]></FromUserName>" +
+      "<CreateTime>1399197672</CreateTime>" +
+      "<MsgType><![CDATA[transfer_customer_service]]></MsgType>" +
+      "</xml>";
+    System.out.println(m.toXml());
+    Assert.assertEquals(m.toXml().replaceAll("\\s", ""), expected.replaceAll("\\s", ""));
+
+
+    expected = " <xml>" +
+      "<ToUserName><![CDATA[touser]]></ToUserName>" +
+      "<FromUserName><![CDATA[fromuser]]></FromUserName>" +
+      "<CreateTime>1399197672</CreateTime>" +
+      "<MsgType><![CDATA[transfer_customer_service]]></MsgType>" +
+      "<TransInfo>" +
+      "<KfAccount><![CDATA[test1@test]]></KfAccount>" +
+      "</TransInfo>" +
+      "</xml>";
+    m = WxMpXmlOutMessage.TRANSFER_CUSTOMER_SERVICE().kfAccount("test1@test").fromUser("fromuser").toUser("touser").build();
+    m.setCreateTime(1399197672L);
+    System.out.println(m.toXml());
+    Assert.assertEquals(m.toXml().replaceAll("\\s", ""), expected.replaceAll("\\s", ""));
+  }
+}


### PR DESCRIPTION
由于XStreamTransformer的限制,工具包中无法增加自定义的消息类型,故在XStreamTransformer中增加了一个注册方法用于新增自定义消息的解析
fix #225 修改me.chanjar.weixin.mp.bean.WxMpXmlOutTransferCustomerServiceMessage 支持将消息转发到多客服(
https://mp.weixin.qq.com/wiki/5/ae230189c9bd07a6b221f48619aeef35.html
)中的两种方式