### PR TITLE
修复微信个性化菜单的问题

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxMenu.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxMenu.java
@@ -1,14 +1,13 @@
 package me.chanjar.weixin.common.bean;
 
+import me.chanjar.weixin.common.util.json.WxGsonBuilder;
+import org.apache.commons.codec.Charsets;
+
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.commons.codec.Charsets;
-
-import me.chanjar.weixin.common.util.json.WxGsonBuilder;
 
 /**
  * 企业号菜单
@@ -136,6 +135,7 @@ public class WxMenu implements Serializable {
     private String province;
     private String city;
     private String clientPlatformType;
+    private String language;
     
     public String getGroupId() {
       return groupId;
@@ -184,8 +184,16 @@ public class WxMenu implements Serializable {
     public void setClientPlatformType(String clientPlatformType) {
       this.clientPlatformType = clientPlatformType;
     }
-	
-    @Override
+
+    public String getLanguage() {
+      return language;
+    }
+
+    public void setLanguage(String language) {
+      this.language = language;
+    }
+
+      @Override
     public String toString() {
       return "matchrule:{" +
           "group_id='" + groupId + '\'' +
@@ -194,6 +202,7 @@ public class WxMenu implements Serializable {
           ", province" + province + '\'' +
           ", city" + city + '\'' +
           ", client_platform_type" + clientPlatformType + '\'' +
+          ", language" + language + '\'' +
           "}";
     }
   }

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/json/WxMenuGsonAdapter.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/json/WxMenuGsonAdapter.java
@@ -8,9 +8,6 @@
  */
 package me.chanjar.weixin.common.util.json;
 
-import java.lang.reflect.Type;
-
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -19,8 +16,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-
 import me.chanjar.weixin.common.bean.WxMenu;
+
+import java.lang.reflect.Type;
 
 /**
  * 
@@ -40,8 +38,7 @@ public class WxMenuGsonAdapter implements JsonSerializer<WxMenu>, JsonDeserializ
     json.add("button", buttonArray);
     
     if (menu.getMatchRule() != null) {
-      Gson gson = new Gson();
-      json.add("matchrule", gson.toJsonTree(menu.getMatchRule()));
+      json.add("matchrule", convertToJson(menu.getMatchRule()));
     }
     
     return json;
@@ -61,6 +58,18 @@ public class WxMenuGsonAdapter implements JsonSerializer<WxMenu>, JsonDeserializ
       buttonJson.add("sub_button", buttonArray);
     }
     return buttonJson;
+  }
+
+  protected JsonObject convertToJson(WxMenu.WxMenuRule menuRule){
+    JsonObject matchRule = new JsonObject();
+    matchRule.addProperty("group_id",menuRule.getGroupId());
+    matchRule.addProperty("sex",menuRule.getSex());
+    matchRule.addProperty("country",menuRule.getCountry());
+    matchRule.addProperty("province",menuRule.getProvince());
+    matchRule.addProperty("city",menuRule.getCity());
+    matchRule.addProperty("client_platform_type",menuRule.getClientPlatformType());
+    matchRule.addProperty("language",menuRule.getLanguage());
+    return matchRule;
   }
 
   public WxMenu deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {

--- a/weixin-java-common/src/test/java/me/chanjar/weixin/common/bean/WxMenuTest.java
+++ b/weixin-java-common/src/test/java/me/chanjar/weixin/common/bean/WxMenuTest.java
@@ -55,6 +55,29 @@ public class WxMenuTest {
     
     Assert.assertEquals(menu.toJson(), json);
   }
+
+  @Test(dataProvider = "wxAddConditionalMenu")
+  public void testAddConditionalToJson(String json) {
+    WxMenu menu = new WxMenu();
+    WxMenuButton button1 = new WxMenuButton();
+    button1.setType("click");
+    button1.setName("今日歌曲");
+    button1.setKey("V1001_TODAY_MUSIC");
+
+    menu.getButtons().add(button1);
+
+    WxMenu.WxMenuRule wxMenuRule = new WxMenu.WxMenuRule();
+    wxMenuRule.setGroupId("2");
+    wxMenuRule.setSex("1");
+    wxMenuRule.setCountry("中国");
+    wxMenuRule.setProvince("广东");
+    wxMenuRule.setCity("广州");
+    wxMenuRule.setClientPlatformType("2");
+    wxMenuRule.setLanguage("zh_CN");
+    menu.setMatchRule(wxMenuRule);
+
+    Assert.assertEquals(menu.toJson(), json);
+  }
   
   @DataProvider
   public Object[][] wxReturnMenu() {
@@ -104,6 +127,32 @@ public class WxMenuTest {
         +"}";
     return new Object[][] {
         new Object[] { json }
+    };
+  }
+
+  @DataProvider(name = "wxAddConditionalMenu")
+  public Object[][] addConditionalMenuJson(){
+    String json =
+        "{"
+            +"\"button\":["
+            +"{"
+            +"\"type\":\"click\","
+            +"\"name\":\"今日歌曲\","
+            +"\"key\":\"V1001_TODAY_MUSIC\""
+            +"}"
+            +"],"
+            +"\"matchrule\":{"
+              +"\"group_id\":\"2\","
+              +"\"sex\":\"1\","
+              +"\"country\":\"中国\","
+              +"\"province\":\"广东\","
+              +"\"city\":\"广州\","
+              +"\"client_platform_type\":\"2\","
+              +"\"language\":\"zh_CN\""
+            +"}"
+            +"}";
+    return new Object[][]{
+        new Object[]{json}
     };
   }
   


### PR DESCRIPTION
1.WxMenuRule增加language字段
2.更改了WxMenu的toJson方法使matchrule转换成正确的字符串(修复不能正确创建个性化菜单的问题)
    针对WxMenuRule增加了convertToJson 方法，去掉了原先通过Gson转成Json串的方法
3.WxMenuTest中增加了相应的测试用例（testAddConditionalToJson 方法）