### PR TITLE
修改设置代理的Bug。

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddGetRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddGetRequestExecutor.java
@@ -33,7 +33,7 @@ public class JoddGetRequestExecutor implements RequestExecutor<String, String> {
         if (httpProxy != null) {
             ProxyInfo proxyInfoObj = new ProxyInfo(
                 ProxyInfo.ProxyType.HTTP,
-                httpProxy.getAddress().getHostAddress(),
+                httpProxy.getHostName(),
                 httpProxy.getPort(), "", "");
             provider.useProxy(proxyInfoObj);
         }


### PR DESCRIPTION
HttpProxy 初始化固定address为null，new ProxyInfo时调用getAddress().getHostAddress产生NullPointException. 

Signed-off-by: Wang Zhengjie <wangzhengjie@tinkers.com.cn>