### PR TITLE
更新 WxMpServiceImpl.java和WxMpService.java类

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <httpclient.version>4.5</httpclient.version>
     <slf4j.version>1.7.10</slf4j.version>
     <logback.version>1.1.2</logback.version>
+    <jodd-http.version>3.6.7</jodd-http.version>
   </properties>
 
   <dependencies>
@@ -67,6 +68,11 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
       <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jodd</groupId>
+      <artifactId>jodd-http</artifactId>
+      <version>${jodd-http.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>me.chanjar</groupId>
   <artifactId>weixin-java-parent</artifactId>
-  <version>1.3.3</version>
+  <version>1.3.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>WeiXin Java Tools - Parent</name>
   <description>微信公众号、企业号上级POM</description>

--- a/weixin-java-common/pom.xml
+++ b/weixin-java-common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>me.chanjar</groupId>
     <artifactId>weixin-java-parent</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>weixin-java-common</artifactId>

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/api/WxConsts.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/api/WxConsts.java
@@ -47,7 +47,7 @@ public class WxConsts {
   ///////////////////////
   public static final String MASS_ST_SUCCESS = "send success";
   public static final String MASS_ST_FAIL = "send fail";
-  public static final String MASS_ST_涉嫌广告 = "err(10001)"; 
+  public static final String MASS_ST_涉嫌广告 = "err(10001)";
   public static final String MASS_ST_涉嫌政治 = "err(20001)";
   public static final String MASS_ST_涉嫌社会 = "err(20004)";
   public static final String MASS_ST_涉嫌色情 = "err(20002)";
@@ -93,6 +93,15 @@ public class WxConsts {
   public static final String EVT_LOCATION_SELECT = "location_select";
   public static final String EVT_TEMPLATESENDJOBFINISH = "TEMPLATESENDJOBFINISH";
   public static final String EVT_ENTER_AGENT = "enter_agent";
+  public static final String EVT_CARD_PASS_CHECK = "card_pass_check";
+  public static final String EVT_CARD_NOT_PASS_CHECK = "card_not_pass_check";
+  public static final String EVT_USER_GET_CARD = "user_get_card";
+  public static final String EVT_USER_DEL_CARD = "user_del_card";
+  public static final String EVT_USER_CONSUME_CARD = "user_consume_card";
+  public static final String EVT_USER_PAY_FROM_PAY_CELL = "user_pay_from_pay_cell";
+  public static final String EVT_USER_VIEW_CARD = "user_view_card";
+  public static final String EVT_USER_ENTER_SESSION_FROM_CARD = "user_enter_session_from_card";
+  public static final String EVT_CARD_SKU_REMIND = "card_sku_remind"; // 库存报警
 
   ///////////////////////
   // 上传多媒体文件的类型

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxCardApiSignature.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxCardApiSignature.java
@@ -1,0 +1,102 @@
+package me.chanjar.weixin.common.bean;
+
+import java.io.Serializable;
+
+/**
+ * 卡券Api签名
+ *
+ * @author YuJian
+ * @version 15/11/8
+ */
+public class WxCardApiSignature implements Serializable {
+
+    private String appId;
+
+    private String cardId;
+
+    private String cardType;
+
+    private String locationId;
+
+    private String code;
+
+    private String openId;
+
+    private Long timestamp;
+
+    private String nonceStr;
+
+    private String signature;
+
+    public String getAppId() {
+      return appId;
+    }
+
+    public void setAppId(String appId) {
+      this.appId = appId;
+    }
+
+    public String getCardId() {
+      return cardId;
+    }
+
+    public void setCardId(String cardId) {
+      this.cardId = cardId;
+    }
+
+    public String getCardType() {
+      return cardType;
+    }
+
+    public void setCardType(String cardType) {
+      this.cardType = cardType;
+    }
+
+    public String getLocationId() {
+      return locationId;
+    }
+
+  public void setLocationId(String locationId) {
+    this.locationId = locationId;
+  }
+
+  public String getCode() {
+      return code;
+    }
+
+    public void setCode(String code) {
+      this.code = code;
+    }
+
+    public String getOpenId() {
+      return openId;
+    }
+
+    public void setOpenId(String openId) {
+      this.openId = openId;
+    }
+
+    public Long getTimestamp() {
+      return timestamp;
+    }
+
+    public void setTimestamp(Long timestamp) {
+      this.timestamp = timestamp;
+    }
+
+    public String getNonceStr() {
+      return nonceStr;
+    }
+
+    public void setNonceStr(String nonceStr) {
+      this.nonceStr = nonceStr;
+    }
+
+    public String getSignature() {
+      return signature;
+    }
+
+    public void setSignature(String signature) {
+      this.signature = signature;
+    }
+}

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxMenu.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxMenu.java
@@ -1,14 +1,13 @@
 package me.chanjar.weixin.common.bean;
 
+import me.chanjar.weixin.common.util.json.WxGsonBuilder;
+import org.apache.commons.codec.Charsets;
+
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.commons.codec.Charsets;
-
-import me.chanjar.weixin.common.util.json.WxGsonBuilder;
 
 /**
  * 企业号菜单
@@ -136,6 +135,7 @@ public class WxMenu implements Serializable {
     private String province;
     private String city;
     private String clientPlatformType;
+    private String language;
     
     public String getGroupId() {
       return groupId;
@@ -184,8 +184,16 @@ public class WxMenu implements Serializable {
     public void setClientPlatformType(String clientPlatformType) {
       this.clientPlatformType = clientPlatformType;
     }
-	
-    @Override
+
+    public String getLanguage() {
+      return language;
+    }
+
+    public void setLanguage(String language) {
+      this.language = language;
+    }
+
+      @Override
     public String toString() {
       return "matchrule:{" +
           "group_id='" + groupId + '\'' +
@@ -194,6 +202,7 @@ public class WxMenu implements Serializable {
           ", province" + province + '\'' +
           ", city" + city + '\'' +
           ", client_platform_type" + clientPlatformType + '\'' +
+          ", language" + language + '\'' +
           "}";
     }
   }

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/ApacheHttpClientBuilder.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/ApacheHttpClientBuilder.java
@@ -1,0 +1,51 @@
+package me.chanjar.weixin.common.util.http;
+
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+/**
+ * httpclient build interface
+ */
+public interface ApacheHttpClientBuilder {
+
+  /**
+   * 构建httpclient实例
+   * @return new instance of CloseableHttpClient
+   */
+  CloseableHttpClient build();
+
+  /**
+   * 代理服务器地址
+   * @param httpProxyHost
+   * @return
+   */
+  ApacheHttpClientBuilder httpProxyHost(String httpProxyHost);
+
+  /**
+   * 代理服务器端口
+   * @param httpProxyPort
+   * @return
+   */
+  ApacheHttpClientBuilder httpProxyPort(int httpProxyPort);
+
+  /**
+   * 代理服务器用户名
+   * @param httpProxyUsername
+   * @return
+   */
+  ApacheHttpClientBuilder httpProxyUsername(String httpProxyUsername);
+
+  /**
+   * 代理服务器密码
+   * @param httpProxyPassword
+   * @return
+   */
+  ApacheHttpClientBuilder httpProxyPassword(String httpProxyPassword);
+
+  /**
+   * ssl连接socket工厂
+   * @param sslConnectionSocketFactory
+   * @return
+   */
+  ApacheHttpClientBuilder sslConnectionSocketFactory(SSLConnectionSocketFactory sslConnectionSocketFactory);
+}

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/DefaultApacheHttpHttpClientBuilder.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/DefaultApacheHttpHttpClientBuilder.java
@@ -1,0 +1,199 @@
+package me.chanjar.weixin.common.util.http;
+
+import me.chanjar.weixin.common.util.StringUtils;
+import org.apache.http.annotation.NotThreadSafe;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * httpclient 连接管理器
+ */
+@NotThreadSafe
+public class DefaultApacheHttpHttpClientBuilder implements ApacheHttpClientBuilder {
+  private int connectionRequestTimeout = 3000;
+  private int connectionTimeout = 5000;
+  private int soTimeout = 5000;
+  private int idleConnTimeout = 60000;
+  private int checkWaitTime = 5000;
+  private int maxConnPerHost = 10;
+  private int maxTotalConn = 50;
+  private String userAgent;
+  private HttpRequestRetryHandler httpRequestRetryHandler = new HttpRequestRetryHandler() {
+    @Override
+    public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
+      return false;
+    }
+  };
+  private SSLConnectionSocketFactory sslConnectionSocketFactory = SSLConnectionSocketFactory.getSocketFactory();
+  private PlainConnectionSocketFactory plainConnectionSocketFactory = PlainConnectionSocketFactory.getSocketFactory();
+
+  private String httpProxyHost;
+  private int httpProxyPort;
+  private String httpProxyUsername;
+  private String httpProxyPassword;
+
+  /**
+   * 连接管理器
+   */
+  private PoolingHttpClientConnectionManager connectionManager;
+  /**
+   * 闲置连接监控线程
+   */
+  private IdleConnectionMonitorThread idleConnectionMonitorThread;
+
+  /**
+   * httpClientBuilder
+   */
+  private HttpClientBuilder httpClientBuilder;
+
+  private boolean prepared = false;
+
+  private DefaultApacheHttpHttpClientBuilder() {
+  }
+
+  public static DefaultApacheHttpHttpClientBuilder get() {
+    return new DefaultApacheHttpHttpClientBuilder();
+  }
+
+  public ApacheHttpClientBuilder httpProxyHost(String httpProxyHost) {
+    this.httpProxyHost = httpProxyHost;
+    return this;
+  }
+
+  public ApacheHttpClientBuilder httpProxyPort(int httpProxyPort) {
+    this.httpProxyPort = httpProxyPort;
+    return this;
+  }
+
+  public ApacheHttpClientBuilder httpProxyUsername(String httpProxyUsername) {
+    this.httpProxyUsername = httpProxyUsername;
+    return this;
+  }
+
+  public ApacheHttpClientBuilder httpProxyPassword(String httpProxyPassword) {
+    this.httpProxyPassword = httpProxyPassword;
+    return this;
+  }
+
+  public ApacheHttpClientBuilder sslConnectionSocketFactory(SSLConnectionSocketFactory sslConnectionSocketFactory){
+    this.sslConnectionSocketFactory = sslConnectionSocketFactory;
+    return this;
+  }
+
+  public IdleConnectionMonitorThread getIdleConnectionMonitorThread() {
+    return idleConnectionMonitorThread;
+  }
+
+  private void prepare(){
+    Registry<ConnectionSocketFactory> registry = RegistryBuilder.<ConnectionSocketFactory>create()
+      .register("http", plainConnectionSocketFactory)
+      .register("https", sslConnectionSocketFactory)
+      .build();
+    connectionManager = new PoolingHttpClientConnectionManager(registry);
+    connectionManager.setMaxTotal(maxTotalConn);
+    connectionManager.setDefaultMaxPerRoute(maxConnPerHost);
+    connectionManager.setDefaultSocketConfig(
+      SocketConfig.copy(SocketConfig.DEFAULT)
+        .setSoTimeout(soTimeout)
+        .build()
+    );
+
+    idleConnectionMonitorThread = new IdleConnectionMonitorThread(connectionManager, idleConnTimeout, checkWaitTime);
+    idleConnectionMonitorThread.setDaemon(true);
+    idleConnectionMonitorThread.start();
+
+    httpClientBuilder = HttpClients.custom()
+      .setConnectionManager(connectionManager)
+      .setDefaultRequestConfig(
+        RequestConfig.custom()
+          .setSocketTimeout(soTimeout)
+          .setConnectTimeout(connectionTimeout)
+          .setConnectionRequestTimeout(connectionRequestTimeout)
+          .build()
+      )
+      .setRetryHandler(httpRequestRetryHandler);
+
+    if (StringUtils.isNotBlank(httpProxyHost) && StringUtils.isNotBlank(httpProxyUsername)) {
+      // 使用代理服务器 需要用户认证的代理服务器
+      CredentialsProvider credsProvider = new BasicCredentialsProvider();
+      credsProvider.setCredentials(
+        new AuthScope(httpProxyHost, httpProxyPort),
+        new UsernamePasswordCredentials(httpProxyUsername, httpProxyPassword));
+      httpClientBuilder.setDefaultCredentialsProvider(credsProvider);
+    }
+
+    if (StringUtils.isNotBlank(userAgent)) {
+      httpClientBuilder.setUserAgent(userAgent);
+    }
+
+  }
+
+  public CloseableHttpClient build() {
+    if(!prepared){
+      prepare();
+      prepared = true;
+    }
+
+    return httpClientBuilder.build();
+  }
+
+  public static class IdleConnectionMonitorThread extends Thread {
+    private final HttpClientConnectionManager connMgr;
+    private final int idleConnTimeout;
+    private final int checkWaitTime;
+    private volatile boolean shutdown;
+
+    public IdleConnectionMonitorThread(HttpClientConnectionManager connMgr, int idleConnTimeout, int checkWaitTime) {
+      super("IdleConnectionMonitorThread");
+      this.connMgr = connMgr;
+      this.idleConnTimeout = idleConnTimeout;
+      this.checkWaitTime = checkWaitTime;
+    }
+
+    @Override
+    public void run() {
+      try {
+        while (!shutdown) {
+          synchronized (this) {
+            wait(checkWaitTime);
+            connMgr.closeExpiredConnections();
+            connMgr.closeIdleConnections(idleConnTimeout, TimeUnit.MILLISECONDS);
+          }
+        }
+      } catch (InterruptedException ignore) {
+      }
+    }
+
+    public void trigger() {
+      synchronized (this) {
+        notifyAll();
+      }
+    }
+
+    public void shutdown() {
+      shutdown = true;
+      synchronized (this) {
+        notifyAll();
+      }
+    }
+  }
+}

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddGetRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddGetRequestExecutor.java
@@ -43,6 +43,7 @@ public class JoddGetRequestExecutor implements RequestExecutor<String, String> {
         request.charset("UTF-8");
 
         HttpResponse response = request.open(provider).send();
+        response.charset("UTF-8");
         String result = response.bodyText();
 
         WxError error = WxError.fromJson(result);

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddGetRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddGetRequestExecutor.java
@@ -1,0 +1,55 @@
+package me.chanjar.weixin.common.util.http;
+
+import jodd.http.HttpRequest;
+import jodd.http.HttpResponse;
+import jodd.http.ProxyInfo;
+import jodd.http.net.SocketHttpConnectionProvider;
+import me.chanjar.weixin.common.bean.result.WxError;
+import me.chanjar.weixin.common.exception.WxErrorException;
+import org.apache.http.HttpHost;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import java.io.IOException;
+
+/**
+ * 简单的GET请求执行器，请求的参数是String, 返回的结果也是String
+ *
+ * @author Daniel Qian
+ */
+public class JoddGetRequestExecutor implements RequestExecutor<String, String> {
+
+    @Override
+    public String execute(CloseableHttpClient httpclient, HttpHost httpProxy, String uri,
+        String queryParam) throws WxErrorException, IOException {
+        if (queryParam != null) {
+            if (uri.indexOf('?') == -1) {
+                uri += '?';
+            }
+            uri += uri.endsWith("?") ? queryParam : '&' + queryParam;
+        }
+
+        SocketHttpConnectionProvider provider = new SocketHttpConnectionProvider();
+
+        if (httpProxy != null) {
+            ProxyInfo proxyInfoObj = new ProxyInfo(
+                ProxyInfo.ProxyType.HTTP,
+                httpProxy.getAddress().getHostAddress(),
+                httpProxy.getPort(), "", "");
+            provider.useProxy(proxyInfoObj);
+        }
+
+        HttpRequest request = HttpRequest.get(uri);
+        request.method("GET");
+        request.charset("UTF-8");
+
+        HttpResponse response = request.open(provider).send();
+        String result = response.bodyText();
+
+        WxError error = WxError.fromJson(result);
+        if (error.getErrorCode() != 0) {
+            throw new WxErrorException(error);
+        }
+        return result;
+    }
+
+}

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddGetRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddGetRequestExecutor.java
@@ -33,7 +33,7 @@ public class JoddGetRequestExecutor implements RequestExecutor<String, String> {
         if (httpProxy != null) {
             ProxyInfo proxyInfoObj = new ProxyInfo(
                 ProxyInfo.ProxyType.HTTP,
-                httpProxy.getAddress().getHostAddress(),
+                httpProxy.getHostName(),
                 httpProxy.getPort(), "", "");
             provider.useProxy(proxyInfoObj);
         }

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddPostRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddPostRequestExecutor.java
@@ -37,6 +37,7 @@ public class JoddPostRequestExecutor implements RequestExecutor<String, String> 
         request.bodyText(postEntity);
 
         HttpResponse response = request.open(provider).send();
+        response.charset("UTF-8");
         String result = response.bodyText();
 
         WxError error = WxError.fromJson(result);

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddPostRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/JoddPostRequestExecutor.java
@@ -1,0 +1,49 @@
+package me.chanjar.weixin.common.util.http;
+
+import jodd.http.HttpRequest;
+import jodd.http.HttpResponse;
+import jodd.http.ProxyInfo;
+import jodd.http.net.SocketHttpConnectionProvider;
+import me.chanjar.weixin.common.bean.result.WxError;
+import me.chanjar.weixin.common.exception.WxErrorException;
+import org.apache.http.HttpHost;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import java.io.IOException;
+
+/**
+ * 简单的POST请求执行器，请求的参数是String, 返回的结果也是String
+ *
+ * @author Edison Guo
+ */
+public class JoddPostRequestExecutor implements RequestExecutor<String, String> {
+
+    @Override
+    public String execute(CloseableHttpClient httpclient, HttpHost httpProxy, String uri,
+        String postEntity) throws WxErrorException, IOException {
+        SocketHttpConnectionProvider provider = new SocketHttpConnectionProvider();
+
+        if (httpProxy != null) {
+            ProxyInfo proxyInfoObj = new ProxyInfo(
+                ProxyInfo.ProxyType.HTTP,
+                httpProxy.getAddress().getHostAddress(),
+                httpProxy.getPort(), "", "");
+            provider.useProxy(proxyInfoObj);
+        }
+
+        HttpRequest request = HttpRequest.get(uri);
+        request.method("POST");
+        request.charset("UTF-8");
+        request.bodyText(postEntity);
+
+        HttpResponse response = request.open(provider).send();
+        String result = response.bodyText();
+
+        WxError error = WxError.fromJson(result);
+        if (error.getErrorCode() != 0) {
+            throw new WxErrorException(error);
+        }
+        return result;
+    }
+
+}

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/MediaDownloadRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/MediaDownloadRequestExecutor.java
@@ -74,6 +74,8 @@ public class MediaDownloadRequestExecutor implements RequestExecutor<File, Strin
       File localFile = FileUtils.createTmpFile(inputStream, name_ext[0], name_ext[1], tmpDirFile);
       return localFile;
 
+    }finally {
+      httpGet.releaseConnection();
     }
 
   }

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/MediaUploadRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/MediaUploadRequestExecutor.java
@@ -1,9 +1,8 @@
 package me.chanjar.weixin.common.util.http;
 
-import java.io.File;
-import java.io.IOException;
-
+import me.chanjar.weixin.common.bean.result.WxError;
 import me.chanjar.weixin.common.bean.result.WxMediaUploadResult;
+import me.chanjar.weixin.common.exception.WxErrorException;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.client.ClientProtocolException;
@@ -13,10 +12,10 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.HttpMultipartMode;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
-
-import me.chanjar.weixin.common.bean.result.WxError;
-import me.chanjar.weixin.common.exception.WxErrorException;
 import org.apache.http.impl.client.CloseableHttpClient;
+
+import java.io.File;
+import java.io.IOException;
 
 /**
  * 上传媒体文件请求执行器，请求的参数是File, 返回的结果是String
@@ -48,6 +47,8 @@ public class MediaUploadRequestExecutor implements RequestExecutor<WxMediaUpload
         throw new WxErrorException(error);
       }
       return WxMediaUploadResult.fromJson(responseContent);
+    }finally {
+      httpPost.releaseConnection();
     }
   }
 

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/SimpleGetRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/SimpleGetRequestExecutor.java
@@ -1,16 +1,15 @@
 package me.chanjar.weixin.common.util.http;
 
-import java.io.IOException;
-
+import me.chanjar.weixin.common.bean.result.WxError;
+import me.chanjar.weixin.common.exception.WxErrorException;
 import org.apache.http.HttpHost;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-
-import me.chanjar.weixin.common.bean.result.WxError;
-import me.chanjar.weixin.common.exception.WxErrorException;
 import org.apache.http.impl.client.CloseableHttpClient;
+
+import java.io.IOException;
 
 /**
  * 简单的GET请求执行器，请求的参数是String, 返回的结果也是String
@@ -40,6 +39,8 @@ public class SimpleGetRequestExecutor implements RequestExecutor<String, String>
         throw new WxErrorException(error);
       }
       return responseContent;
+    }finally {
+      httpGet.releaseConnection();
     }
   }
 

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/SimplePostRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/SimplePostRequestExecutor.java
@@ -1,24 +1,17 @@
 package me.chanjar.weixin.common.util.http;
 
-import java.io.IOException;
-
 import me.chanjar.weixin.common.bean.result.WxError;
 import me.chanjar.weixin.common.exception.WxErrorException;
 import org.apache.http.Consts;
 import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
 
 /**
  * 简单的POST请求执行器，请求的参数是String, 返回的结果也是String
@@ -47,6 +40,8 @@ public class SimplePostRequestExecutor implements RequestExecutor<String, String
         throw new WxErrorException(error);
       }
       return responseContent;
+    }finally {
+      httpPost.releaseConnection();
     }
   }
 

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/json/WxMenuGsonAdapter.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/json/WxMenuGsonAdapter.java
@@ -8,9 +8,6 @@
  */
 package me.chanjar.weixin.common.util.json;
 
-import java.lang.reflect.Type;
-
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -19,8 +16,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-
 import me.chanjar.weixin.common.bean.WxMenu;
+
+import java.lang.reflect.Type;
 
 /**
  * 
@@ -40,8 +38,7 @@ public class WxMenuGsonAdapter implements JsonSerializer<WxMenu>, JsonDeserializ
     json.add("button", buttonArray);
     
     if (menu.getMatchRule() != null) {
-      Gson gson = new Gson();
-      json.add("matchrule", gson.toJsonTree(menu.getMatchRule()));
+      json.add("matchrule", convertToJson(menu.getMatchRule()));
     }
     
     return json;
@@ -61,6 +58,18 @@ public class WxMenuGsonAdapter implements JsonSerializer<WxMenu>, JsonDeserializ
       buttonJson.add("sub_button", buttonArray);
     }
     return buttonJson;
+  }
+
+  protected JsonObject convertToJson(WxMenu.WxMenuRule menuRule){
+    JsonObject matchRule = new JsonObject();
+    matchRule.addProperty("group_id",menuRule.getGroupId());
+    matchRule.addProperty("sex",menuRule.getSex());
+    matchRule.addProperty("country",menuRule.getCountry());
+    matchRule.addProperty("province",menuRule.getProvince());
+    matchRule.addProperty("city",menuRule.getCity());
+    matchRule.addProperty("client_platform_type",menuRule.getClientPlatformType());
+    matchRule.addProperty("language",menuRule.getLanguage());
+    return matchRule;
   }
 
   public WxMenu deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {

--- a/weixin-java-common/src/test/java/me/chanjar/weixin/common/bean/WxMenuTest.java
+++ b/weixin-java-common/src/test/java/me/chanjar/weixin/common/bean/WxMenuTest.java
@@ -55,6 +55,29 @@ public class WxMenuTest {
     
     Assert.assertEquals(menu.toJson(), json);
   }
+
+  @Test(dataProvider = "wxAddConditionalMenu")
+  public void testAddConditionalToJson(String json) {
+    WxMenu menu = new WxMenu();
+    WxMenuButton button1 = new WxMenuButton();
+    button1.setType("click");
+    button1.setName("今日歌曲");
+    button1.setKey("V1001_TODAY_MUSIC");
+
+    menu.getButtons().add(button1);
+
+    WxMenu.WxMenuRule wxMenuRule = new WxMenu.WxMenuRule();
+    wxMenuRule.setGroupId("2");
+    wxMenuRule.setSex("1");
+    wxMenuRule.setCountry("中国");
+    wxMenuRule.setProvince("广东");
+    wxMenuRule.setCity("广州");
+    wxMenuRule.setClientPlatformType("2");
+    wxMenuRule.setLanguage("zh_CN");
+    menu.setMatchRule(wxMenuRule);
+
+    Assert.assertEquals(menu.toJson(), json);
+  }
   
   @DataProvider
   public Object[][] wxReturnMenu() {
@@ -104,6 +127,32 @@ public class WxMenuTest {
         +"}";
     return new Object[][] {
         new Object[] { json }
+    };
+  }
+
+  @DataProvider(name = "wxAddConditionalMenu")
+  public Object[][] addConditionalMenuJson(){
+    String json =
+        "{"
+            +"\"button\":["
+            +"{"
+            +"\"type\":\"click\","
+            +"\"name\":\"今日歌曲\","
+            +"\"key\":\"V1001_TODAY_MUSIC\""
+            +"}"
+            +"],"
+            +"\"matchrule\":{"
+              +"\"group_id\":\"2\","
+              +"\"sex\":\"1\","
+              +"\"country\":\"中国\","
+              +"\"province\":\"广东\","
+              +"\"city\":\"广州\","
+              +"\"client_platform_type\":\"2\","
+              +"\"language\":\"zh_CN\""
+            +"}"
+            +"}";
+    return new Object[][]{
+        new Object[]{json}
     };
   }
   

--- a/weixin-java-cp/pom.xml
+++ b/weixin-java-cp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.chanjar</groupId>
         <artifactId>weixin-java-parent</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>weixin-java-cp</artifactId>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpConfigStorage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpConfigStorage.java
@@ -1,8 +1,9 @@
 package me.chanjar.weixin.cp.api;
 
-import java.io.File;
-
 import me.chanjar.weixin.common.bean.WxAccessToken;
+import me.chanjar.weixin.common.util.http.ApacheHttpClientBuilder;
+
+import java.io.File;
 
 /**
  * 微信客户端配置存储
@@ -63,4 +64,9 @@ public interface WxCpConfigStorage {
   
   public File getTmpDirFile();
 
+  /**
+   * http client builder
+   * @return ApacheHttpClientBuilder
+   */
+  public ApacheHttpClientBuilder getApacheHttpClientBuilder();
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpInMemoryConfigStorage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpInMemoryConfigStorage.java
@@ -1,8 +1,9 @@
 package me.chanjar.weixin.cp.api;
 
-import java.io.File;
-
 import me.chanjar.weixin.common.bean.WxAccessToken;
+import me.chanjar.weixin.common.util.http.ApacheHttpClientBuilder;
+
+import java.io.File;
 
 /**
  * 基于内存的微信配置provider，在实际生产环境中应该将这些配置持久化
@@ -31,6 +32,8 @@ public class WxCpInMemoryConfigStorage implements WxCpConfigStorage {
   protected volatile long jsapiTicketExpiresTime;
 
   protected volatile File tmpDirFile;
+
+  private volatile ApacheHttpClientBuilder apacheHttpClientBuilder;
 
   public String getAccessToken() {
     return this.accessToken;
@@ -205,4 +208,12 @@ public class WxCpInMemoryConfigStorage implements WxCpConfigStorage {
     this.tmpDirFile = tmpDirFile;
   }
 
+  @Override
+  public ApacheHttpClientBuilder getApacheHttpClientBuilder() {
+    return this.apacheHttpClientBuilder;
+  }
+
+  public void setApacheHttpClientBuilder(ApacheHttpClientBuilder apacheHttpClientBuilder) {
+    this.apacheHttpClientBuilder = apacheHttpClientBuilder;
+  }
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpServiceImpl.java
@@ -25,8 +25,8 @@ import me.chanjar.weixin.common.util.fs.FileUtils;
 import me.chanjar.weixin.common.util.http.MediaDownloadRequestExecutor;
 import me.chanjar.weixin.common.util.http.MediaUploadRequestExecutor;
 import me.chanjar.weixin.common.util.http.RequestExecutor;
-import me.chanjar.weixin.common.util.http.SimpleGetRequestExecutor;
-import me.chanjar.weixin.common.util.http.SimplePostRequestExecutor;
+import me.chanjar.weixin.common.util.http.JoddGetRequestExecutor;
+import me.chanjar.weixin.common.util.http.JoddPostRequestExecutor;
 import me.chanjar.weixin.common.util.http.URIUtil;
 import me.chanjar.weixin.common.util.json.GsonHelper;
 import me.chanjar.weixin.cp.bean.WxCpDepart;
@@ -156,7 +156,7 @@ public class WxCpServiceImpl implements WxCpService {
       synchronized (globalJsapiTicketRefreshLock) {
         if (wxCpConfigStorage.isJsapiTicketExpired()) {
           String url = "https://qyapi.weixin.qq.com/cgi-bin/get_jsapi_ticket";
-          String responseContent = execute(new SimpleGetRequestExecutor(), url, null);
+          String responseContent = execute(new JoddGetRequestExecutor(), url, null);
           JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
           JsonObject tmpJsonObject = tmpJsonElement.getAsJsonObject();
           String jsapiTicket = tmpJsonObject.get("ticket").getAsString();
@@ -256,7 +256,7 @@ public class WxCpServiceImpl implements WxCpService {
   public Integer departCreate(WxCpDepart depart) throws WxErrorException {
     String url = "https://qyapi.weixin.qq.com/cgi-bin/department/create";
     String responseContent = execute(
-        new SimplePostRequestExecutor(),
+        new JoddPostRequestExecutor(),
         url,
         depart.toJson());
     JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
@@ -512,11 +512,11 @@ public class WxCpServiceImpl implements WxCpService {
   }
 
   public String get(String url, String queryParam) throws WxErrorException {
-    return execute(new SimpleGetRequestExecutor(), url, queryParam);
+    return execute(new JoddGetRequestExecutor(), url, queryParam);
   }
 
   public String post(String url, String postData) throws WxErrorException {
-    return execute(new SimplePostRequestExecutor(), url, postData);
+    return execute(new JoddPostRequestExecutor(), url, postData);
   }
 
   /**
@@ -685,12 +685,5 @@ public class WxCpServiceImpl implements WxCpService {
     this.tmpDirFile = tmpDirFile;
   }
 
-  public static void main(String[] args) {
-    Float a = 3.1f;
-    System.out.println(3.1d);
-    System.out.println(new BigDecimal(3.1d));
-    System.out.println(new BigDecimal(a));
-    System.out.println(a.toString());
-    System.out.println(a.doubleValue());
-  }
+
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/xml/XStreamTransformer.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/xml/XStreamTransformer.java
@@ -32,6 +32,15 @@ public class XStreamTransformer {
   }
 
   /**
+   * 注册扩展消息的解析器
+   * @param clz 类型
+   * @param xStream xml解析器
+     */
+  public static void register(Class clz,XStream xStream){
+    CLASS_2_XSTREAM_INSTANCE.put(clz,xStream);
+  }
+
+  /**
    * pojo -> xml
    *
    * @param clazz

--- a/weixin-java-mp/pom.xml
+++ b/weixin-java-mp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>me.chanjar</groupId>
         <artifactId>weixin-java-parent</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
     <artifactId>weixin-java-mp</artifactId>
     <name>WeiXin Java Tools - MP</name>

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpConfigStorage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpConfigStorage.java
@@ -50,6 +50,21 @@ public interface WxMpConfigStorage {
    */
   public void updateJsapiTicket(String jsapiTicket, int expiresInSeconds);
 
+  public String getCardApiTicket();
+
+  public boolean isCardApiTicketExpired();
+
+  /**
+   * 强制将卡券api ticket过期掉
+   */
+  public void expireCardApiTicket();
+
+  /**
+   * 应该是线程安全的
+   * @param cardApiTicket
+   */
+  public void updateCardApiTicket(String cardApiTicket, int expiresInSeconds);
+
   public String getAppId();
 
   public String getSecret();

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpConfigStorage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpConfigStorage.java
@@ -1,10 +1,10 @@
 package me.chanjar.weixin.mp.api;
 
-import java.io.File;
+import me.chanjar.weixin.common.bean.WxAccessToken;
+import me.chanjar.weixin.common.util.http.ApacheHttpClientBuilder;
 
 import javax.net.ssl.SSLContext;
-
-import me.chanjar.weixin.common.bean.WxAccessToken;
+import java.io.File;
 
 /**
  * 微信客户端配置存储
@@ -92,4 +92,10 @@ public interface WxMpConfigStorage {
   public File getTmpDirFile();
 
   public SSLContext getSSLContext();
+
+  /**
+   * http client builder
+   * @return ApacheHttpClientBuilder
+   */
+  public ApacheHttpClientBuilder getApacheHttpClientBuilder();
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpInMemoryConfigStorage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpInMemoryConfigStorage.java
@@ -32,6 +32,9 @@ public class WxMpInMemoryConfigStorage implements WxMpConfigStorage {
   protected volatile String jsapiTicket;
   protected volatile long jsapiTicketExpiresTime;
 
+  protected volatile String cardApiTicket;
+  protected volatile long cardApiTicketExpiresTime;
+
   /**
    * 临时文件目录
    */
@@ -88,6 +91,27 @@ public class WxMpInMemoryConfigStorage implements WxMpConfigStorage {
 
   public void expireJsapiTicket() {
     this.jsapiTicketExpiresTime = 0;
+  }
+
+  /**
+   * 卡券api_ticket
+   */
+  public String getCardApiTicket() {
+    return cardApiTicket;
+  }
+
+  public boolean isCardApiTicketExpired() {
+    return System.currentTimeMillis() > this.cardApiTicketExpiresTime;
+  }
+
+  public synchronized void updateCardApiTicket(String cardApiTicket, int expiresInSeconds) {
+    this.cardApiTicket = cardApiTicket;
+    // 预留200秒的时间
+    this.cardApiTicketExpiresTime = System.currentTimeMillis() + (expiresInSeconds - 200) * 1000l;
+  }
+
+  public void expireCardApiTicket() {
+    this.cardApiTicketExpiresTime = 0;
   }
 
   public String getAppId() {
@@ -192,6 +216,8 @@ public class WxMpInMemoryConfigStorage implements WxMpConfigStorage {
         ", http_proxy_password='" + http_proxy_password + '\'' +
         ", jsapiTicket='" + jsapiTicket + '\'' +
         ", jsapiTicketExpiresTime='" + jsapiTicketExpiresTime + '\'' +
+        ", cardApiTicket='" + cardApiTicket + '\'' +
+        ", cardApiTicketExpiresTime='" + cardApiTicketExpiresTime + '\'' +
         ", tmpDirFile='" + tmpDirFile + '\'' +
         '}';
   }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpInMemoryConfigStorage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpInMemoryConfigStorage.java
@@ -1,10 +1,10 @@
 package me.chanjar.weixin.mp.api;
 
-import java.io.File;
+import me.chanjar.weixin.common.bean.WxAccessToken;
+import me.chanjar.weixin.common.util.http.ApacheHttpClientBuilder;
 
 import javax.net.ssl.SSLContext;
-
-import me.chanjar.weixin.common.bean.WxAccessToken;
+import java.io.File;
 
 /**
  * 基于内存的微信配置provider，在实际生产环境中应该将这些配置持久化
@@ -41,7 +41,9 @@ public class WxMpInMemoryConfigStorage implements WxMpConfigStorage {
   protected volatile File tmpDirFile;
   
   protected volatile SSLContext sslContext;
-  
+
+  protected volatile ApacheHttpClientBuilder apacheHttpClientBuilder;
+
   public String getAccessToken() {
     return this.accessToken;
   }
@@ -258,4 +260,12 @@ public class WxMpInMemoryConfigStorage implements WxMpConfigStorage {
     sslContext = context;
   }
 
+  @Override
+  public ApacheHttpClientBuilder getApacheHttpClientBuilder() {
+    return this.apacheHttpClientBuilder;
+  }
+
+  public void setApacheHttpClientBuilder(ApacheHttpClientBuilder apacheHttpClientBuilder) {
+    this.apacheHttpClientBuilder = apacheHttpClientBuilder;
+  }
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
@@ -1,5 +1,6 @@
 package me.chanjar.weixin.mp.api;
 
+import me.chanjar.weixin.common.bean.WxCardApiSignature;
 import me.chanjar.weixin.common.bean.WxMenu;
 import me.chanjar.weixin.common.bean.WxJsapiSignature;
 import me.chanjar.weixin.common.bean.result.WxMediaUploadResult;
@@ -770,7 +771,7 @@ public interface WxMpService {
      * @return
      */
     public boolean checkJSSDKCallbackDataSignature(Map<String, String> kvm, String signature);
-    
+
    /**
     * 发送微信红包给个人用户
     * @param parameters
@@ -778,4 +779,81 @@ public interface WxMpService {
     * @throws WxErrorException
     */
     public WxRedpackResult sendRedpack(Map<String, String> parameters) throws WxErrorException;
+
+  /**
+   * 获得卡券api_ticket，不强制刷新卡券api_ticket
+   * @see #getCardApiTicket(boolean)
+   * @return 卡券api_ticket
+   * @throws WxErrorException
+   */
+  public String getCardApiTicket() throws WxErrorException;
+
+  /**
+   * <pre>
+   * 获得卡券api_ticket
+   * 获得时会检查卡券apiToken是否过期，如果过期了，那么就刷新一下，否则就什么都不干
+   *
+   * 详情请见：http://mp.weixin.qq.com/wiki/7/aaa137b55fb2e0456bf8dd9148dd613f.html#.E9.99.84.E5.BD.954-.E5.8D.A1.E5.88.B8.E6.89.A9.E5.B1.95.E5.AD.97.E6.AE.B5.E5.8F.8A.E7.AD.BE.E5.90.8D.E7.94.9F.E6.88.90.E7.AE.97.E6.B3.95
+   * </pre>
+   * @param forceRefresh 强制刷新
+   * @return 卡券api_ticket
+   * @throws WxErrorException
+   */
+  public String getCardApiTicket(boolean forceRefresh) throws WxErrorException;
+
+  /**
+   * <pre>
+   * 创建调用卡券api时所需要的签名
+   *
+   * 详情请见：http://mp.weixin.qq.com/wiki/7/aaa137b55fb2e0456bf8dd9148dd613f.html#.E9.99.84.E5.BD
+   * .954-.E5.8D.A1.E5.88.B8.E6.89.A9.E5.B1.95.E5.AD.97.E6.AE.B5.E5.8F.8A.E7.AD.BE.E5.90.8D.E7.94
+   * .9F.E6.88.90.E7.AE.97.E6.B3.95
+   * </pre>
+   *
+   * @param optionalSignParam 参与签名的参数数组。
+   *                  可以为下列字段：app_id, card_id, card_type, code, openid, location_id
+   * @return 卡券Api签名对象
+   */
+  public WxCardApiSignature createCardApiSignature(String... optionalSignParam) throws
+      WxErrorException;
+
+  /**
+   * 卡券Code解码
+   * @param encryptCode 加密Code，通过JSSDK的chooseCard接口获得
+   * @return 解密后的Code
+   * @throws WxErrorException
+   */
+  public String decryptCardCode(String encryptCode) throws WxErrorException;
+
+  /**
+   * 卡券Code查询
+   * @param cardId 卡券ID代表一类卡券
+   * @param code 单张卡券的唯一标准
+   * @param checkConsume 是否校验code核销状态，填入true和false时的code异常状态返回数据不同
+   * @return WxMpCardResult对象
+   * @throws WxErrorException
+   */
+  public WxMpCardResult queryCardCode(String cardId, String code, boolean checkConsume)
+    throws WxErrorException;
+    
+   /**
+   * 卡券Code核销。核销失败会抛出异常
+   * @param code 单张卡券的唯一标准
+    * @return
+    * @throws WxErrorException
+    */
+  public void consumeCardCode(String code) throws WxErrorException;
+
+    /**
+     * 卡券Mark接口。
+     * 开发者在帮助消费者核销卡券之前，必须帮助先将此code（卡券串码）与一个openid绑定（即mark住），
+     * 才能进一步调用核销接口，否则报错。
+     * @param code 卡券的code码
+     * @param cardId 卡券的ID
+     * @param openId 用券用户的openid
+     * @param isMark 是否要mark（占用）这个code，填写true或者false，表示占用或解除占用
+     * @throws WxErrorException
+     */
+  public void markCardCode(String code, String cardId, String openId, boolean isMark) throws
+      WxErrorException;
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
@@ -721,31 +721,49 @@ public interface WxMpService {
   WxMpPrepayIdResult getPrepayId(Map<String, String> parameters);
 
   /**
-   * 该接口调用“统一下单”接口，并拼装JSSDK发起支付请求需要的参数
+   * 该接口调用“统一下单”接口，并拼装发起支付请求需要的参数
    * 详见http://mp.weixin.qq.com/wiki/7/aaa137b55fb2e0456bf8dd9148dd613f.html#.E5.8F.91.E8.B5.B7.E4.B8.80.E4.B8.AA.E5.BE.AE.E4.BF.A1.E6.94.AF.E4.BB.98.E8.AF.B7.E6.B1.82
    * @param parameters
    *            the required or optional parameters
    * @return
  * @throws WxErrorException 
    */
-  Map<String, String> getJSSDKPayInfo(Map<String, String> parameters) throws WxErrorException;  	
+  Map<String, String> getPayInfo(Map<String, String> parameters) throws WxErrorException;  	
   	
   /**
-   * 该接口调用“统一下单”接口，并拼装JSSDK发起支付请求需要的参数
+   * 该接口调用“统一下单”接口，并拼装NATIVE发起支付请求需要的参数
    * 详见http://mp.weixin.qq.com/wiki/7/aaa137b55fb2e0456bf8dd9148dd613f.html#.E5.8F.91.E8.B5.B7.E4.B8.80.E4.B8.AA.E5.BE.AE.E4.BF.A1.E6.94.AF.E4.BB.98.E8.AF.B7.E6.B1.82
-   * @param openId 支付人openId
+   * tradeType 交易类型 NATIVE （其他交易类型JSAPI，APP，WAP） 
+   * @param productId 商户商品ID
    * @param outTradeNo 商户端对应订单号
    * @param amt 金额(单位元)
    * @param body 商品描述
-   * @param tradeType 交易类型 JSAPI，NATIVE，APP，WAP
    * @param ip 发起支付的客户端IP
    * @param notifyUrl 通知地址
    * @return
  * @throws WxErrorException 
-   * @deprecated Use me.chanjar.weixin.mp.api.WxMpService.getJSSDKPayInfo(Map<String, String>) instead
+   * @deprecated Use me.chanjar.weixin.mp.api.WxMpService.getPayInfo(Map<String, String>) instead
    */
   @Deprecated
-  Map<String, String> getJSSDKPayInfo(String openId, String outTradeNo, double amt, String body, String tradeType, String ip, String notifyUrl) throws WxErrorException;
+  Map<String, String> getNativePayInfo(String productId, String outTradeNo, double amt, String body, String ip, String notifyUrl) throws WxErrorException;
+
+  /**
+   * 该接口调用“统一下单”接口，并拼装JSAPI发起支付请求需要的参数
+   * 详见http://mp.weixin.qq.com/wiki/7/aaa137b55fb2e0456bf8dd9148dd613f.html#.E5.8F.91.E8.B5.B7.E4.B8.80.E4.B8.AA.E5.BE.AE.E4.BF.A1.E6.94.AF.E4.BB.98.E8.AF.B7.E6.B1.82
+   * tradeType 交易类型 JSAPI(其他交易类型NATIVE，APP，WAP)
+   * @param openId 支付人openId
+   * @param outTradeNo 商户端对应订单号
+   * @param amt 金额(单位元)
+   * @param body 商品描述
+   * @param ip 发起支付的客户端IP
+   * @param notifyUrl 通知地址
+   * @return
+ * @throws WxErrorException 
+   * @deprecated Use me.chanjar.weixin.mp.api.WxMpService.getPayInfo(Map<String, String>) instead
+   */
+  @Deprecated
+  Map<String, String> getJsapiPayInfo(String openId, String outTradeNo, double amt, String body, String ip, String notifyUrl) throws WxErrorException;
+
 
     /**
      * 该接口提供所有微信支付订单的查询,当支付通知处理异常戒丢失的情冴,商户可以通过该接口查询订单支付状态。

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
@@ -726,8 +726,9 @@ public interface WxMpService {
    * @param parameters
    *            the required or optional parameters
    * @return
+ * @throws WxErrorException 
    */
-  Map<String, String> getJSSDKPayInfo(Map<String, String> parameters);  	
+  Map<String, String> getJSSDKPayInfo(Map<String, String> parameters) throws WxErrorException;  	
   	
   /**
    * 该接口调用“统一下单”接口，并拼装JSSDK发起支付请求需要的参数
@@ -740,10 +741,11 @@ public interface WxMpService {
    * @param ip 发起支付的客户端IP
    * @param notifyUrl 通知地址
    * @return
+ * @throws WxErrorException 
    * @deprecated Use me.chanjar.weixin.mp.api.WxMpService.getJSSDKPayInfo(Map<String, String>) instead
    */
   @Deprecated
-  Map<String, String> getJSSDKPayInfo(String openId, String outTradeNo, double amt, String body, String tradeType, String ip, String notifyUrl);
+  Map<String, String> getJSSDKPayInfo(String openId, String outTradeNo, double amt, String body, String tradeType, String ip, String notifyUrl) throws WxErrorException;
 
     /**
      * 该接口提供所有微信支付订单的查询,当支付通知处理异常戒丢失的情冴,商户可以通过该接口查询订单支付状态。

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
@@ -762,6 +762,20 @@ public interface WxMpService {
     WxMpPayCallback getJSSDKCallbackData(String xmlData);
     
     /**
+     * 微信支付-申请退款
+     * 详见 https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=9_4
+     * @param parameters 需要传入的退款参数的Map。以下几项为参数的必须项：<br/>
+     *        <li/> transaction_id
+     *        <li/> out_trade_no （仅在上述transaction_id为空时是必须项）
+     *        <li/> out_refund_no
+     *        <li/> total_fee
+     *        <li/> refund_fee
+     * @return 退款操作结果
+     * @throws WxErrorException 
+     */
+    public WxMpPayRefundResult refundPay(Map<String, String> parameters) throws WxErrorException;
+    
+    /**
      * <pre>
      * 计算Map键值对是否和签名相符,
      * 按照字段名的 ASCII 码从小到大排序(字典序)后,使用 URL 键值对的 格式(即 key1=value1&key2=value2...)拼接成字符串
@@ -812,6 +826,7 @@ public interface WxMpService {
    *
    * @param optionalSignParam 参与签名的参数数组。
    *                  可以为下列字段：app_id, card_id, card_type, code, openid, location_id
+   *                  </br>注意：当做wx.chooseCard调用时，必须传入app_id参与签名，否则会造成签名失败导致拉取卡券列表为空
    * @return 卡券Api签名对象
    */
   public WxCardApiSignature createCardApiSignature(String... optionalSignParam) throws
@@ -839,10 +854,12 @@ public interface WxMpService {
    /**
    * 卡券Code核销。核销失败会抛出异常
    * @param code 单张卡券的唯一标准
-    * @return
-    * @throws WxErrorException
-    */
-  public void consumeCardCode(String code) throws WxErrorException;
+   * @param cardId 当自定义Code卡券时需要传入card_id
+   * @return 调用返回的JSON字符串。
+   *         <br>可用 com.google.gson.JsonParser#parse 等方法直接取JSON串中的errcode等信息。
+   * @throws WxErrorException
+   */
+  public String consumeCardCode(String code, String cardId) throws WxErrorException;
 
     /**
      * 卡券Mark接口。
@@ -856,4 +873,15 @@ public interface WxMpService {
      */
   public void markCardCode(String code, String cardId, String openId, boolean isMark) throws
       WxErrorException;
+  
+  /**
+   * 查看卡券详情接口
+   * 详见 https://mp.weixin.qq.com/wiki/14/8dd77aeaee85f922db5f8aa6386d385e.html#.E6.9F.A5.E7.9C.8B.E5.8D.A1.E5.88.B8.E8.AF.A6.E6.83.85
+   * @param cardId 卡券的ID
+   * @return 返回的卡券详情JSON字符串
+   *         <br> [注] 由于返回的JSON格式过于复杂，难以定义其对应格式的Bean并且难以维护，因此只返回String格式的JSON串。
+   *         <br> 可由 com.google.gson.JsonParser#parse 等方法直接取JSON串中的某个字段。
+   * @throws WxErrorException
+   */
+  public String getCardDetail(String cardId) throws WxErrorException;
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -884,7 +884,7 @@ public class WxMpServiceImpl implements WxMpService {
     packageParams.put("mch_id", wxMpConfigStorage.getPartnerId());
     packageParams.put("body", body);
     packageParams.put("out_trade_no", outTradeNo);
-    packageParams.put("total_fee", (int) (amt * 100) + "");
+    packageParams.put("total_fee", String.format("%.0f", amt * 100));
     packageParams.put("spbill_create_ip", ip);
     packageParams.put("notify_url", callbackUrl);
     packageParams.put("trade_type", tradeType);

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -14,8 +15,10 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
 
+import com.google.gson.JsonPrimitive;
 import me.chanjar.weixin.common.api.WxConsts;
 import me.chanjar.weixin.common.bean.WxAccessToken;
+import me.chanjar.weixin.common.bean.WxCardApiSignature;
 import me.chanjar.weixin.common.bean.WxJsapiSignature;
 import me.chanjar.weixin.common.bean.WxMenu;
 import me.chanjar.weixin.common.bean.result.WxError;
@@ -43,6 +46,7 @@ import me.chanjar.weixin.mp.bean.WxMpMaterialArticleUpdate;
 import me.chanjar.weixin.mp.bean.WxMpMaterialNews;
 import me.chanjar.weixin.mp.bean.WxMpSemanticQuery;
 import me.chanjar.weixin.mp.bean.WxMpTemplateMessage;
+import me.chanjar.weixin.mp.bean.result.WxMpCardResult;
 import me.chanjar.weixin.mp.bean.result.WxMpMassSendResult;
 import me.chanjar.weixin.mp.bean.result.WxMpMassUploadResult;
 import me.chanjar.weixin.mp.bean.result.WxMpMaterialCountResult;
@@ -111,6 +115,11 @@ public class WxMpServiceImpl implements WxMpService {
    * 全局的是否正在刷新jsapi_ticket的锁
    */
   protected final Object globalJsapiTicketRefreshLock = new Object();
+
+  /**
+   * 全局的是否正在刷新卡券api_ticket的锁
+   */
+  protected final Object globalCardApiTicketRefreshLock = new Object();
 
   protected WxMpConfigStorage wxMpConfigStorage;
 
@@ -1004,6 +1013,174 @@ public class WxMpServiceImpl implements WxMpService {
       WxError error = new WxError();
       error.setErrorCode(-1);
       throw new WxErrorException(error);
+    }
+  }
+
+  /**
+   * 获得卡券api_ticket，不强制刷新卡券api_ticket
+   *
+   * @return 卡券api_ticket
+   * @throws WxErrorException
+   * @see #getCardApiTicket(boolean)
+   */
+  @Override
+  public String getCardApiTicket() throws WxErrorException {
+    return getCardApiTicket(false);
+  }
+
+  /**
+   * <pre>
+   * 获得卡券api_ticket
+   * 获得时会检查卡券apiToken是否过期，如果过期了，那么就刷新一下，否则就什么都不干
+   *
+   * 详情请见：http://mp.weixin.qq.com/wiki/7/aaa137b55fb2e0456bf8dd9148dd613f.html#.E9.99.84.E5.BD
+   * .954-.E5.8D.A1.E5.88.B8.E6.89.A9.E5.B1.95.E5.AD.97.E6.AE.B5.E5.8F.8A.E7.AD.BE.E5.90.8D.E7.94
+   * .9F.E6.88.90.E7.AE.97.E6.B3.95
+   * </pre>
+   *
+   * @param forceRefresh 强制刷新
+   * @return 卡券api_ticket
+   * @throws WxErrorException
+   */
+  @Override
+  public String getCardApiTicket(boolean forceRefresh) throws WxErrorException {
+    if (forceRefresh) {
+      wxMpConfigStorage.expireCardApiTicket();
+    }
+    if (wxMpConfigStorage.isCardApiTicketExpired()) {
+      synchronized (globalCardApiTicketRefreshLock) {
+        if (wxMpConfigStorage.isCardApiTicketExpired()) {
+          String url = "https://api.weixin.qq.com/cgi-bin/ticket/getticket?type=wx_card";
+          String responseContent = execute(new SimpleGetRequestExecutor(), url, null);
+          JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
+          JsonObject tmpJsonObject = tmpJsonElement.getAsJsonObject();
+          String cardApiTicket = tmpJsonObject.get("ticket").getAsString();
+          int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
+          wxMpConfigStorage.updateCardApiTicket(cardApiTicket, expiresInSeconds);
+        }
+      }
+    }
+    return wxMpConfigStorage.getCardApiTicket();
+  }
+
+  /**
+   * <pre>
+   * 创建调用卡券api时所需要的签名
+   *
+   * 详情请见：http://mp.weixin.qq.com/wiki/7/aaa137b55fb2e0456bf8dd9148dd613f.html#.E9.99.84.E5.BD
+   * .954-.E5.8D.A1.E5.88.B8.E6.89.A9.E5.B1.95.E5.AD.97.E6.AE.B5.E5.8F.8A.E7.AD.BE.E5.90.8D.E7.94
+   * .9F.E6.88.90.E7.AE.97.E6.B3.95
+   * </pre>
+   *
+   * @param optionalSignParam 参与签名的参数数组。
+   *                  可以为下列字段：app_id, card_id, card_type, code, openid, location_id
+   * @return 卡券Api签名对象
+   */
+  @Override
+  public WxCardApiSignature createCardApiSignature(String... optionalSignParam) throws
+      WxErrorException {
+    long timestamp = System.currentTimeMillis() / 1000;
+    String nonceStr = RandomUtils.getRandomStr();
+    String cardApiTicket = getCardApiTicket(false);
+
+    String[] signParam = Arrays.copyOf(optionalSignParam, optionalSignParam.length + 3);
+    signParam[optionalSignParam.length] = String.valueOf(timestamp);
+    signParam[optionalSignParam.length + 1] = nonceStr;
+    signParam[optionalSignParam.length + 2] = cardApiTicket;
+    try {
+      String signature = SHA1.gen(signParam);
+      WxCardApiSignature cardApiSignature = new WxCardApiSignature();
+      cardApiSignature.setTimestamp(timestamp);
+      cardApiSignature.setNonceStr(nonceStr);
+      cardApiSignature.setSignature(signature);
+      return cardApiSignature;
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * 卡券Code解码
+   *
+   * @param encryptCode 加密Code，通过JSSDK的chooseCard接口获得
+   * @return 解密后的Code
+   * @throws WxErrorException
+   */
+  @Override
+  public String decryptCardCode(String encryptCode) throws WxErrorException {
+    String url = "https://api.weixin.qq.com/card/code/decrypt";
+    JsonObject param = new JsonObject();
+    param.addProperty("encrypt_code", encryptCode);
+    String responseContent = post(url, param.toString());
+    JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
+    JsonObject tmpJsonObject = tmpJsonElement.getAsJsonObject();
+    JsonPrimitive jsonPrimitive = tmpJsonObject.getAsJsonPrimitive("code");
+    return jsonPrimitive.getAsString();
+  }
+
+  /**
+   * 卡券Code查询
+   *
+   * @param cardId       卡券ID代表一类卡券
+   * @param code         单张卡券的唯一标准
+   * @param checkConsume 是否校验code核销状态，填入true和false时的code异常状态返回数据不同
+   * @return WxMpCardResult对象
+   * @throws WxErrorException
+   */
+  @Override
+  public WxMpCardResult queryCardCode(String cardId, String code, boolean checkConsume) throws WxErrorException {
+    String url = "https://api.weixin.qq.com/card/code/get";
+    JsonObject param = new JsonObject();
+    param.addProperty("card_id", cardId);
+    param.addProperty("code", code);
+    param.addProperty("check_consume", checkConsume);
+    String responseContent = post(url, param.toString());
+    JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
+    return WxMpGsonBuilder.INSTANCE.create().fromJson(tmpJsonElement,
+        new TypeToken<WxMpCardResult>() {
+        }.getType());
+  }
+
+  /**
+   * 卡券Code核销。核销失败会抛出异常
+   *
+   * @param code 单张卡券的唯一标准
+   * @throws WxErrorException
+   */
+  @Override
+  public void consumeCardCode(String code) throws WxErrorException {
+    String url = "https://api.weixin.qq.com/card/code/consume";
+    JsonObject param = new JsonObject();
+    param.addProperty("code", code);
+    post(url, param.toString());
+  }
+
+  /**
+   * 卡券Mark接口。
+   * 开发者在帮助消费者核销卡券之前，必须帮助先将此code（卡券串码）与一个openid绑定（即mark住），
+   * 才能进一步调用核销接口，否则报错。
+   *
+   * @param code   卡券的code码
+   * @param cardId 卡券的ID
+   * @param openId 用券用户的openid
+   * @param isMark 是否要mark（占用）这个code，填写true或者false，表示占用或解除占用
+   * @throws WxErrorException
+   */
+  @Override
+  public void markCardCode(String code, String cardId, String openId, boolean isMark) throws
+      WxErrorException {
+    String url = "https://api.weixin.qq.com/card/code/mark";
+    JsonObject param = new JsonObject();
+    param.addProperty("code", code);
+    param.addProperty("card_id", cardId);
+    param.addProperty("openid", openId);
+    param.addProperty("is_mark", isMark);
+    String responseContent = post(url, param.toString());
+    JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
+    WxMpCardResult cardResult = WxMpGsonBuilder.INSTANCE.create().fromJson(tmpJsonElement,
+        new TypeToken<WxMpCardResult>() { }.getType());
+    if (!cardResult.getErrorCode().equals("0")) {
+      log.warn("朋友的券mark失败：{}", cardResult.getErrorMsg());
     }
   }
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -28,13 +28,7 @@ import me.chanjar.weixin.common.util.StringUtils;
 import me.chanjar.weixin.common.util.crypto.SHA1;
 import me.chanjar.weixin.common.util.crypto.WxCryptUtil;
 import me.chanjar.weixin.common.util.fs.FileUtils;
-import me.chanjar.weixin.common.util.http.MediaDownloadRequestExecutor;
-import me.chanjar.weixin.common.util.http.MediaUploadRequestExecutor;
-import me.chanjar.weixin.common.util.http.RequestExecutor;
-import me.chanjar.weixin.common.util.http.SimpleGetRequestExecutor;
-import me.chanjar.weixin.common.util.http.SimplePostRequestExecutor;
-import me.chanjar.weixin.common.util.http.URIUtil;
-import me.chanjar.weixin.common.util.http.Utf8ResponseHandler;
+import me.chanjar.weixin.common.util.http.*;
 import me.chanjar.weixin.common.util.json.GsonHelper;
 import me.chanjar.weixin.common.util.json.WxGsonBuilder;
 import me.chanjar.weixin.common.util.xml.XStreamInitializer;
@@ -190,7 +184,7 @@ public class WxMpServiceImpl implements WxMpService {
       synchronized (globalJsapiTicketRefreshLock) {
         if (wxMpConfigStorage.isJsapiTicketExpired()) {
           String url = "https://api.weixin.qq.com/cgi-bin/ticket/getticket?type=jsapi";
-          String responseContent = execute(new SimpleGetRequestExecutor(), url, null);
+          String responseContent = execute(new JoddGetRequestExecutor(), url, null);
           JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
           JsonObject tmpJsonObject = tmpJsonElement.getAsJsonObject();
           String jsapiTicket = tmpJsonObject.get("ticket").getAsString();
@@ -227,33 +221,33 @@ public class WxMpServiceImpl implements WxMpService {
 
   public void customMessageSend(WxMpCustomMessage message) throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/message/custom/send";
-    execute(new SimplePostRequestExecutor(), url, message.toJson());
+    execute(new JoddPostRequestExecutor(), url, message.toJson());
   }
 
   public void menuCreate(WxMenu menu) throws WxErrorException {
     if (menu.getMatchRule() != null) {
       String url = "https://api.weixin.qq.com/cgi-bin/menu/addconditional";
-      execute(new SimplePostRequestExecutor(), url, menu.toJson());
+      execute(new JoddPostRequestExecutor(), url, menu.toJson());
     } else {
       String url = "https://api.weixin.qq.com/cgi-bin/menu/create";
-      execute(new SimplePostRequestExecutor(), url, menu.toJson());
+      execute(new JoddPostRequestExecutor(), url, menu.toJson());
     }
   }
 
   public void menuDelete() throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/menu/delete";
-    execute(new SimpleGetRequestExecutor(), url, null);
+    execute(new JoddGetRequestExecutor(), url, null);
   }
   
   public void menuDelete(String menuid) throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/menu/delconditional";
-    execute(new SimpleGetRequestExecutor(), url, "menuid=" + menuid);
+    execute(new JoddGetRequestExecutor(), url, "menuid=" + menuid);
   }
 
   public WxMenu menuGet() throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/menu/get";
     try {
-      String resultContent = execute(new SimpleGetRequestExecutor(), url, null);
+      String resultContent = execute(new JoddGetRequestExecutor(), url, null);
       return WxMenu.fromJson(resultContent);
     } catch (WxErrorException e) {
       // 46003 不存在的菜单数据
@@ -267,7 +261,7 @@ public class WxMpServiceImpl implements WxMpService {
   public WxMenu menuTryMatch(String userid) throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/menu/trymatch";
     try {
-      String resultContent = execute(new SimpleGetRequestExecutor(), url, "user_id=" + userid);
+      String resultContent = execute(new JoddGetRequestExecutor(), url, "user_id=" + userid);
       return WxMenu.fromJson(resultContent);
     } catch (WxErrorException e) {
       // 46003 不存在的菜单数据     46002 不存在的菜单版本
@@ -380,25 +374,25 @@ public class WxMpServiceImpl implements WxMpService {
 
   public WxMpMassUploadResult massNewsUpload(WxMpMassNews news) throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/media/uploadnews";
-    String responseContent = execute(new SimplePostRequestExecutor(), url, news.toJson());
+    String responseContent = execute(new JoddPostRequestExecutor(), url, news.toJson());
     return WxMpMassUploadResult.fromJson(responseContent);
   }
 
   public WxMpMassUploadResult massVideoUpload(WxMpMassVideo video) throws WxErrorException {
     String url = "http://file.api.weixin.qq.com/cgi-bin/media/uploadvideo";
-    String responseContent = execute(new SimplePostRequestExecutor(), url, video.toJson());
+    String responseContent = execute(new JoddPostRequestExecutor(), url, video.toJson());
     return WxMpMassUploadResult.fromJson(responseContent);
   }
 
   public WxMpMassSendResult massGroupMessageSend(WxMpMassGroupMessage message) throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/message/mass/sendall";
-    String responseContent = execute(new SimplePostRequestExecutor(), url, message.toJson());
+    String responseContent = execute(new JoddPostRequestExecutor(), url, message.toJson());
     return WxMpMassSendResult.fromJson(responseContent);
   }
 
   public WxMpMassSendResult massOpenIdsMessageSend(WxMpMassOpenIdsMessage message) throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/message/mass/send";
-    String responseContent = execute(new SimplePostRequestExecutor(), url, message.toJson());
+    String responseContent = execute(new JoddPostRequestExecutor(), url, message.toJson());
     return WxMpMassSendResult.fromJson(responseContent);
   }
 
@@ -410,7 +404,7 @@ public class WxMpServiceImpl implements WxMpService {
     groupJson.addProperty("name", name);
 
     String responseContent = execute(
-        new SimplePostRequestExecutor(),
+        new JoddPostRequestExecutor(),
         url,
         json.toString());
     return WxMpGroup.fromJson(responseContent);
@@ -418,7 +412,7 @@ public class WxMpServiceImpl implements WxMpService {
 
   public List<WxMpGroup> groupGet() throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/groups/get";
-    String responseContent = execute(new SimpleGetRequestExecutor(), url, null);
+    String responseContent = execute(new JoddGetRequestExecutor(), url, null);
     /*
      * 操蛋的微信API，创建时返回的是 { group : { id : ..., name : ...} }
      * 查询时返回的是 { groups : [ { id : ..., name : ..., count : ... }, ... ] }
@@ -433,14 +427,14 @@ public class WxMpServiceImpl implements WxMpService {
     String url = "https://api.weixin.qq.com/cgi-bin/groups/getid";
     JsonObject o = new JsonObject();
     o.addProperty("openid", openid);
-    String responseContent = execute(new SimplePostRequestExecutor(), url, o.toString());
+    String responseContent = execute(new JoddPostRequestExecutor(), url, o.toString());
     JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
     return GsonHelper.getAsLong(tmpJsonElement.getAsJsonObject().get("groupid"));
   }
 
   public void groupUpdate(WxMpGroup group) throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/groups/update";
-    execute(new SimplePostRequestExecutor(), url, group.toJson());
+    execute(new JoddPostRequestExecutor(), url, group.toJson());
   }
 
   public void userUpdateGroup(String openid, long to_groupid) throws WxErrorException {
@@ -448,7 +442,7 @@ public class WxMpServiceImpl implements WxMpService {
     JsonObject json = new JsonObject();
     json.addProperty("openid", openid);
     json.addProperty("to_groupid", to_groupid);
-    execute(new SimplePostRequestExecutor(), url, json.toString());
+    execute(new JoddPostRequestExecutor(), url, json.toString());
   }
 
   public void userUpdateRemark(String openid, String remark) throws WxErrorException {
@@ -456,19 +450,19 @@ public class WxMpServiceImpl implements WxMpService {
     JsonObject json = new JsonObject();
     json.addProperty("openid", openid);
     json.addProperty("remark", remark);
-    execute(new SimplePostRequestExecutor(), url, json.toString());
+    execute(new JoddPostRequestExecutor(), url, json.toString());
   }
 
   public WxMpUser userInfo(String openid, String lang) throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/user/info";
     lang = lang == null ? "zh_CN" : lang;
-    String responseContent = execute(new SimpleGetRequestExecutor(), url, "openid=" + openid + "&lang=" + lang);
+    String responseContent = execute(new JoddGetRequestExecutor(), url, "openid=" + openid + "&lang=" + lang);
     return WxMpUser.fromJson(responseContent);
   }
 
   public WxMpUserList userList(String next_openid) throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/user/get";
-    String responseContent = execute(new SimpleGetRequestExecutor(), url, next_openid == null ? null : "next_openid=" + next_openid);
+    String responseContent = execute(new JoddGetRequestExecutor(), url, next_openid == null ? null : "next_openid=" + next_openid);
     return WxMpUserList.fromJson(responseContent);
   }
 
@@ -484,7 +478,7 @@ public class WxMpServiceImpl implements WxMpService {
     scene.addProperty("scene_id", scene_id);
     actionInfo.add("scene", scene);
     json.add("action_info", actionInfo);
-    String responseContent = execute(new SimplePostRequestExecutor(), url, json.toString());
+    String responseContent = execute(new JoddPostRequestExecutor(), url, json.toString());
     return WxMpQrCodeTicket.fromJson(responseContent);
   }
 
@@ -497,7 +491,7 @@ public class WxMpServiceImpl implements WxMpService {
     scene.addProperty("scene_id", scene_id);
     actionInfo.add("scene", scene);
     json.add("action_info", actionInfo);
-    String responseContent = execute(new SimplePostRequestExecutor(), url, json.toString());
+    String responseContent = execute(new JoddPostRequestExecutor(), url, json.toString());
     return WxMpQrCodeTicket.fromJson(responseContent);
   }
 
@@ -510,7 +504,7 @@ public class WxMpServiceImpl implements WxMpService {
     scene.addProperty("scene_str", scene_str);
     actionInfo.add("scene", scene);
     json.add("action_info", actionInfo);
-    String responseContent = execute(new SimplePostRequestExecutor(), url, json.toString());
+    String responseContent = execute(new JoddPostRequestExecutor(), url, json.toString());
     return WxMpQrCodeTicket.fromJson(responseContent);
   }
 
@@ -524,14 +518,14 @@ public class WxMpServiceImpl implements WxMpService {
     JsonObject o = new JsonObject();
     o.addProperty("action", "long2short");
     o.addProperty("long_url", long_url);
-    String responseContent = execute(new SimplePostRequestExecutor(), url, o.toString());
+    String responseContent = execute(new JoddPostRequestExecutor(), url, o.toString());
     JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
     return tmpJsonElement.getAsJsonObject().get("short_url").getAsString();
   }
 
   public String templateSend(WxMpTemplateMessage templateMessage) throws WxErrorException {
     String url = "https://api.weixin.qq.com/cgi-bin/message/template/send";
-    String responseContent = execute(new SimplePostRequestExecutor(), url, templateMessage.toJson());
+    String responseContent = execute(new JoddPostRequestExecutor(), url, templateMessage.toJson());
     JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
     final JsonObject jsonObject = tmpJsonElement.getAsJsonObject();
     if (jsonObject.get("errcode").getAsInt() == 0)
@@ -541,7 +535,7 @@ public class WxMpServiceImpl implements WxMpService {
 
   public WxMpSemanticQueryResult semanticQuery(WxMpSemanticQuery semanticQuery) throws WxErrorException {
     String url = "https://api.weixin.qq.com/semantic/semproxy/search";
-    String responseContent = execute(new SimplePostRequestExecutor(), url, semanticQuery.toJson());
+    String responseContent = execute(new JoddPostRequestExecutor(), url, semanticQuery.toJson());
     return WxMpSemanticQueryResult.fromJson(responseContent);
   }
 
@@ -573,7 +567,7 @@ public class WxMpServiceImpl implements WxMpService {
     url += "&grant_type=authorization_code";
 
     try {
-      RequestExecutor<String, String> executor = new SimpleGetRequestExecutor();
+      RequestExecutor<String, String> executor = new JoddGetRequestExecutor();
       String responseText = executor.execute(getHttpclient(), httpProxy, url, null);
       return WxMpOAuth2AccessToken.fromJson(responseText);
     } catch (ClientProtocolException e) {
@@ -591,7 +585,7 @@ public class WxMpServiceImpl implements WxMpService {
     url += "&refresh_token=" + refreshToken;
 
     try {
-      RequestExecutor<String, String> executor = new SimpleGetRequestExecutor();
+      RequestExecutor<String, String> executor = new JoddGetRequestExecutor();
       String responseText = executor.execute(getHttpclient(), httpProxy, url, null);
       return WxMpOAuth2AccessToken.fromJson(responseText);
     } catch (ClientProtocolException e) {
@@ -613,7 +607,7 @@ public class WxMpServiceImpl implements WxMpService {
     }
 
     try {
-      RequestExecutor<String, String> executor = new SimpleGetRequestExecutor();
+      RequestExecutor<String, String> executor = new JoddGetRequestExecutor();
       String responseText = executor.execute(getHttpclient(), httpProxy, url, null);
       return WxMpUser.fromJson(responseText);
     } catch (ClientProtocolException e) {
@@ -630,7 +624,7 @@ public class WxMpServiceImpl implements WxMpService {
     url += "&openid=" + oAuth2AccessToken.getOpenId();
 
     try {
-      RequestExecutor<String, String> executor = new SimpleGetRequestExecutor();
+      RequestExecutor<String, String> executor = new JoddGetRequestExecutor();
       executor.execute(getHttpclient(), httpProxy, url, null);
     } catch (ClientProtocolException e) {
       throw new RuntimeException(e);
@@ -683,11 +677,11 @@ public class WxMpServiceImpl implements WxMpService {
   }
 
   public String get(String url, String queryParam) throws WxErrorException {
-    return execute(new SimpleGetRequestExecutor(), url, queryParam);
+    return execute(new JoddGetRequestExecutor(), url, queryParam);
   }
 
   public String post(String url, String postData) throws WxErrorException {
-    return execute(new SimplePostRequestExecutor(), url, postData);
+    return execute(new JoddPostRequestExecutor(), url, postData);
   }
 
   /**

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -158,14 +158,15 @@ public class WxMpServiceImpl implements WxMpService {
               RequestConfig config = RequestConfig.custom().setProxy(httpProxy).build();
               httpGet.setConfig(config);
             }
-            CloseableHttpResponse response = getHttpclient().execute(httpGet);
-            String resultContent = new BasicResponseHandler().handleResponse(response);
-            WxError error = WxError.fromJson(resultContent);
-            if (error.getErrorCode() != 0) {
-              throw new WxErrorException(error);
+            try (CloseableHttpResponse response = getHttpclient().execute(httpGet)) {
+              String resultContent = new BasicResponseHandler().handleResponse(response);
+              WxError error = WxError.fromJson(resultContent);
+              if (error.getErrorCode() != 0) {
+                throw new WxErrorException(error);
+              }
+              WxAccessToken accessToken = WxAccessToken.fromJson(resultContent);
+              wxMpConfigStorage.updateAccessToken(accessToken.getAccessToken(), accessToken.getExpiresIn());
             }
-            WxAccessToken accessToken = WxAccessToken.fromJson(resultContent);
-            wxMpConfigStorage.updateAccessToken(accessToken.getAccessToken(), accessToken.getExpiresIn());
           } catch (ClientProtocolException e) {
             throw new RuntimeException(e);
           } catch (IOException e) {
@@ -851,8 +852,7 @@ public class WxMpServiceImpl implements WxMpService {
 
     StringEntity entity = new StringEntity(request.toString(), Consts.UTF_8);
     httpPost.setEntity(entity);
-    try {
-      CloseableHttpResponse response = getHttpclient().execute(httpPost);
+    try(CloseableHttpResponse response = getHttpclient().execute(httpPost)) {
       String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
       XStream xstream = XStreamInitializer.getInstance();
       xstream.alias("xml", WxMpPrepayIdResult.class);
@@ -944,8 +944,7 @@ public class WxMpServiceImpl implements WxMpService {
 
     StringEntity entity = new StringEntity(request.toString(), Consts.UTF_8);
     httpPost.setEntity(entity);
-    try {
-      CloseableHttpResponse response = httpClient.execute(httpPost);
+    try(CloseableHttpResponse response = httpClient.execute(httpPost)) {
       String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
       XStream xstream = XStreamInitializer.getInstance();
       xstream.alias("xml", WxMpPayResult.class);
@@ -1000,8 +999,7 @@ public class WxMpServiceImpl implements WxMpService {
 
     StringEntity entity = new StringEntity(request.toString(), Consts.UTF_8);
     httpPost.setEntity(entity);
-    try {
-      CloseableHttpResponse response = getHttpclient().execute(httpPost);
+    try(CloseableHttpResponse response = getHttpclient().execute(httpPost)) {
       String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
       XStream xstream = XStreamInitializer.getInstance();
       xstream.processAnnotations(WxRedpackResult.class);

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -1051,7 +1051,7 @@ public class WxMpServiceImpl implements WxMpService {
       synchronized (globalCardApiTicketRefreshLock) {
         if (wxMpConfigStorage.isCardApiTicketExpired()) {
           String url = "https://api.weixin.qq.com/cgi-bin/ticket/getticket?type=wx_card";
-          String responseContent = execute(new SimpleGetRequestExecutor(), url, null);
+          String responseContent = execute(new JoddGetRequestExecutor(), url, null);
           JsonElement tmpJsonElement = Streams.parse(new JsonReader(new StringReader(responseContent)));
           JsonObject tmpJsonObject = tmpJsonElement.getAsJsonObject();
           String cardApiTicket = tmpJsonObject.get("ticket").getAsString();

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -866,6 +866,7 @@ public class WxMpServiceImpl implements WxMpService {
     payInfo.put("nonceStr", System.currentTimeMillis() + "");
     payInfo.put("package", "prepay_id=" + prepayId);
     payInfo.put("signType", "MD5");
+    payInfo.put("code_url",wxMpPrepayIdResult.getCode_url());
 
     String finalSign = WxCryptUtil.createSign(payInfo, wxMpConfigStorage.getPartnerKey());
     payInfo.put("paySign", finalSign);

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpServiceImpl.java
@@ -908,10 +908,10 @@ public class WxMpServiceImpl implements WxMpService {
       WxError error = new WxError();
       error.setErrorCode(-1);
       error.setErrorMsg("return_code:" + wxMpPrepayIdResult.getReturn_code() +
-                        "return_msg:" + wxMpPrepayIdResult.getReturn_msg() +
-                        "result_code:" + wxMpPrepayIdResult.getResult_code() +
-                        "err_code" + wxMpPrepayIdResult.getErr_code() +
-                        "err_code_des" + wxMpPrepayIdResult.getErr_code_des());
+                        ";return_msg:" + wxMpPrepayIdResult.getReturn_msg() +
+                        ";result_code:" + wxMpPrepayIdResult.getResult_code() +
+                        ";err_code" + wxMpPrepayIdResult.getErr_code() +
+                        ";err_code_des" + wxMpPrepayIdResult.getErr_code_des());
       throw new WxErrorException(error);
     }
     
@@ -992,7 +992,7 @@ public class WxMpServiceImpl implements WxMpService {
     SortedMap<String, String> refundParams = new TreeMap<String, String>(parameters);
     refundParams.put("appid", wxMpConfigStorage.getAppId());
     refundParams.put("mch_id", wxMpConfigStorage.getPartnerId());
-    refundParams.put("nonceStr", System.currentTimeMillis() + "");
+    refundParams.put("nonce_str", System.currentTimeMillis() + "");
     refundParams.put("op_user_id", wxMpConfigStorage.getPartnerId());
     String sign = WxCryptUtil.createSign(refundParams, wxMpConfigStorage.getPartnerKey());
     refundParams.put("sign", sign);
@@ -1015,7 +1015,7 @@ public class WxMpServiceImpl implements WxMpService {
       CloseableHttpResponse response = getHttpclient().execute(httpPost)) {
       String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
       XStream xstream = XStreamInitializer.getInstance();
-      xstream.processAnnotations(WxRedpackResult.class);
+      xstream.processAnnotations(WxMpPayRefundResult.class);
       WxMpPayRefundResult wxMpPayRefundResult = (WxMpPayRefundResult) xstream.fromXML(responseContent);
       
       if (!"SUCCESS".equalsIgnoreCase(wxMpPayRefundResult.getResultCode())
@@ -1023,10 +1023,10 @@ public class WxMpServiceImpl implements WxMpService {
         WxError error = new WxError();
         error.setErrorCode(-1);
         error.setErrorMsg("return_code:" + wxMpPayRefundResult.getReturnCode() +
-                          "return_msg:" + wxMpPayRefundResult.getReturnMsg() +
-                          "result_code:" + wxMpPayRefundResult.getResultCode() +
-                          "err_code" + wxMpPayRefundResult.getErrCode() +
-                          "err_code_des" + wxMpPayRefundResult.getErrCodeDes());
+                          ";return_msg:" + wxMpPayRefundResult.getReturnMsg() +
+                          ";result_code:" + wxMpPayRefundResult.getResultCode() +
+                          ";err_code" + wxMpPayRefundResult.getErrCode() +
+                          ";err_code_des" + wxMpPayRefundResult.getErrCodeDes());
         throw new WxErrorException(error);
       }
       

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpCard.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpCard.java
@@ -1,0 +1,72 @@
+package me.chanjar.weixin.mp.bean;
+
+
+/**
+ * 微信卡券
+ *
+ * @author YuJian
+ * @version 15/11/11
+ */
+public class WxMpCard {
+
+  private String cardId;
+
+  private Long beginTime;
+
+  private Long endTime;
+
+  private String userCardStatus;
+
+  private Boolean canConsume;
+
+  public String getCardId() {
+    return cardId;
+  }
+
+  public void setCardId(String cardId) {
+    this.cardId = cardId;
+  }
+
+  public Long getBeginTime() {
+    return beginTime;
+  }
+
+  public void setBeginTime(Long beginTime) {
+    this.beginTime = beginTime;
+  }
+
+  public Long getEndTime() {
+    return endTime;
+  }
+
+  public void setEndTime(Long endTime) {
+    this.endTime = endTime;
+  }
+
+  public String getUserCardStatus() {
+    return userCardStatus;
+  }
+
+  public void setUserCardStatus(String userCardStatus) {
+    this.userCardStatus = userCardStatus;
+  }
+
+  public Boolean getCanConsume() {
+    return canConsume;
+  }
+
+  public void setCanConsume(Boolean canConsume) {
+    this.canConsume = canConsume;
+  }
+
+  @Override
+  public String toString() {
+    return "WxMpCard{" +
+        "cardId='" + cardId + '\'' +
+        ", beginTime=" + beginTime +
+        ", endTime=" + endTime +
+        ", userCardStatus='" + userCardStatus + '\'' +
+        ", canConsume=" + canConsume +
+        '}';
+  }
+}

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlMessage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlMessage.java
@@ -157,6 +157,10 @@ public class WxMpXmlMessage implements Serializable {
   @XStreamConverter(value=XStreamCDataConverter.class)
   private String cardId;
 
+  @XStreamAlias("FriendUserName")
+  @XStreamConverter(value=XStreamCDataConverter.class)
+  private String friendUserName;
+
   @XStreamAlias("IsGiveByFriend")
   private Integer isGiveByFriend; // 是否为转赠，1代表是，0代表否
 
@@ -483,6 +487,14 @@ public class WxMpXmlMessage implements Serializable {
 
   public void setCardId(String cardId) {
     this.cardId = cardId;
+  }
+
+  public String getFriendUserName() {
+    return friendUserName;
+  }
+
+  public void setFriendUserName(String friendUserName) {
+    this.friendUserName = friendUserName;
   }
 
   public Integer getIsGiveByFriend() {

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlMessage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlMessage.java
@@ -150,6 +150,27 @@ public class WxMpXmlMessage implements Serializable {
   @XStreamAlias("ErrorCount")
   private Integer errorCount;
 
+  ///////////////////////////////////////
+  // 卡券相关事件推送
+  ///////////////////////////////////////
+  @XStreamAlias("CardId")
+  @XStreamConverter(value=XStreamCDataConverter.class)
+  private String cardId;
+
+  @XStreamAlias("IsGiveByFriend")
+  private Integer isGiveByFriend; // 是否为转赠，1代表是，0代表否
+
+  @XStreamAlias("UserCardCode")
+  @XStreamConverter(value=XStreamCDataConverter.class)
+  private String userCardCode;
+
+  @XStreamAlias("OldUserCardCode")
+  @XStreamConverter(value=XStreamCDataConverter.class)
+  private String oldUserCardCode;
+
+  @XStreamAlias("OuterId")
+  private Integer outerId;
+
   @XStreamAlias("ScanCodeInfo")
   private ScanCodeInfo scanCodeInfo = new ScanCodeInfo();
 
@@ -456,6 +477,46 @@ public class WxMpXmlMessage implements Serializable {
     this.errorCount = errorCount;
   }
 
+  public String getCardId() {
+    return cardId;
+  }
+
+  public void setCardId(String cardId) {
+    this.cardId = cardId;
+  }
+
+  public Integer getIsGiveByFriend() {
+    return isGiveByFriend;
+  }
+
+  public void setIsGiveByFriend(Integer isGiveByFriend) {
+    this.isGiveByFriend = isGiveByFriend;
+  }
+
+  public String getUserCardCode() {
+    return userCardCode;
+  }
+
+  public void setUserCardCode(String userCardCode) {
+    this.userCardCode = userCardCode;
+  }
+
+  public String getOldUserCardCode() {
+    return oldUserCardCode;
+  }
+
+  public void setOldUserCardCode(String oldUserCardCode) {
+    this.oldUserCardCode = oldUserCardCode;
+  }
+
+  public Integer getOuterId() {
+    return outerId;
+  }
+
+  public void setOuterId(Integer outerId) {
+    this.outerId = outerId;
+  }
+
   public WxMpXmlMessage.ScanCodeInfo getScanCodeInfo() {
     return scanCodeInfo;
   }
@@ -652,6 +713,11 @@ public class WxMpXmlMessage implements Serializable {
         ", filterCount=" + filterCount +
         ", sentCount=" + sentCount +
         ", errorCount=" + errorCount +
+        ", cardId='" + cardId + '\'' +
+        ", isGiveByFriend=" + isGiveByFriend +
+        ", userCardCode='" + userCardCode + '\'' +
+        ", oldUserCardCode='" + oldUserCardCode + '\'' +
+        ", outerId=" + outerId +
         ", scanCodeInfo=" + scanCodeInfo +
         ", sendPicsInfo=" + sendPicsInfo +
         ", sendLocationInfo=" + sendLocationInfo +

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlOutTransferCustomerServiceMessage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpXmlOutTransferCustomerServiceMessage.java
@@ -4,23 +4,22 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import me.chanjar.weixin.common.api.WxConsts;
 import me.chanjar.weixin.common.util.xml.XStreamCDataConverter;
-import me.chanjar.weixin.common.util.xml.XStreamMediaIdConverter;
 
 @XStreamAlias("xml")
 public class WxMpXmlOutTransferCustomerServiceMessage extends WxMpXmlOutMessage {
   @XStreamAlias("TransInfo")
-  protected final TransInfo transInfo = new TransInfo();
+  protected TransInfo transInfo;
 
   public WxMpXmlOutTransferCustomerServiceMessage() {
     this.msgType = WxConsts.CUSTOM_MSG_TRANSFER_CUSTOMER_SERVICE;
   }
 
-  public String getKfAccount() {
-    return transInfo.getKfAccount();
+  public TransInfo getTransInfo() {
+    return transInfo;
   }
 
-  public void setKfAccount(String kfAccount) {
-    transInfo.setKfAccount(kfAccount);
+  public void setTransInfo(TransInfo transInfo) {
+    this.transInfo = transInfo;
   }
 
   @XStreamAlias("TransInfo")

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/outxmlbuilder/TransferCustomerServiceBuilder.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/outxmlbuilder/TransferCustomerServiceBuilder.java
@@ -1,5 +1,6 @@
 package me.chanjar.weixin.mp.bean.outxmlbuilder;
 
+import me.chanjar.weixin.common.util.StringUtils;
 import me.chanjar.weixin.mp.bean.WxMpXmlOutTransferCustomerServiceMessage;
 
 /**
@@ -22,7 +23,11 @@ public final class TransferCustomerServiceBuilder extends BaseBuilder<TransferCu
   public WxMpXmlOutTransferCustomerServiceMessage build() {
     WxMpXmlOutTransferCustomerServiceMessage m = new WxMpXmlOutTransferCustomerServiceMessage();
     setCommon(m);
-    m.setKfAccount(kfAccount);
+    if(StringUtils.isNotBlank(kfAccount)){
+      WxMpXmlOutTransferCustomerServiceMessage.TransInfo transInfo = new WxMpXmlOutTransferCustomerServiceMessage.TransInfo();
+      transInfo.setKfAccount(kfAccount);
+      m.setTransInfo(transInfo);
+    }
     return m;
   }
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpCardResult.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpCardResult.java
@@ -1,0 +1,87 @@
+package me.chanjar.weixin.mp.bean.result;
+
+import me.chanjar.weixin.mp.bean.WxMpCard;
+
+import java.io.Serializable;
+
+/**
+ * 卡券查询Code，核销Code接口返回结果
+ *
+ * @author YuJian
+ * @version 15/11/11
+ */
+public class WxMpCardResult implements Serializable {
+
+  private String errorCode;
+
+  private String errorMsg;
+
+  private String openId;
+
+  private WxMpCard card;
+
+  private String userCardStatus;
+
+  private Boolean canConsume;
+
+  public String getErrorCode() {
+    return errorCode;
+  }
+
+  public void setErrorCode(String errorCode) {
+    this.errorCode = errorCode;
+  }
+
+  public String getErrorMsg() {
+    return errorMsg;
+  }
+
+  public void setErrorMsg(String errorMsg) {
+    this.errorMsg = errorMsg;
+  }
+
+  public String getOpenId() {
+    return openId;
+  }
+
+  public void setOpenId(String openId) {
+    this.openId = openId;
+  }
+
+  public WxMpCard getCard() {
+    return card;
+  }
+
+  public void setCard(WxMpCard card) {
+    this.card = card;
+  }
+
+  @Override
+  public String toString() {
+    return "WxMpCardResult{" +
+        "errorCode='" + errorCode + '\'' +
+        ", errorMsg='" + errorMsg + '\'' +
+        ", openId='" + openId + '\'' +
+        ", card=" + card +
+        ", userCardStatus='" + userCardStatus + '\'' +
+        ", canConsume=" + canConsume +
+        '}';
+  }
+
+  public String getUserCardStatus() {
+    return userCardStatus;
+  }
+
+  public void setUserCardStatus(String userCardStatus) {
+    this.userCardStatus = userCardStatus;
+  }
+
+  public Boolean getCanConsume() {
+    return canConsume;
+  }
+
+  public void setCanConsume(Boolean canConsume) {
+    this.canConsume = canConsume;
+  }
+
+}

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpPayRefundResult.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/result/WxMpPayRefundResult.java
@@ -1,0 +1,278 @@
+package me.chanjar.weixin.mp.bean.result;
+
+import java.io.Serializable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * 微信支付-申请退款返回结果
+ * https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=9_4
+ * @author liukaitj
+ *
+ */
+@XStreamAlias("xml")
+public class WxMpPayRefundResult implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @XStreamAlias("return_code")
+  private String returnCode;
+  
+  @XStreamAlias("return_msg")
+  private String returnMsg;
+  
+  @XStreamAlias("result_code")
+  private String resultCode;
+  
+  @XStreamAlias("err_code")
+  private String errCode;
+  
+  @XStreamAlias("err_code_des")
+  private String errCodeDes;
+  
+  @XStreamAlias("appid")
+  private String appid;
+  
+  @XStreamAlias("mch_id")
+  private String mchId;
+  
+  @XStreamAlias("device_info")
+  private String deviceInfo;
+  
+  @XStreamAlias("nonce_str")
+  private String nonceStr;
+  
+  @XStreamAlias("sign")
+  private String sign;
+  
+  @XStreamAlias("transaction_id")
+  private String transactionId;
+  
+  @XStreamAlias("out_trade_no")
+  private String outTradeNo;
+  
+  @XStreamAlias("out_refund_no")
+  private String outRefundNo;
+  
+  @XStreamAlias("refund_id")
+  private String refundId;
+  
+  @XStreamAlias("refund_channel")
+  private String refundChannel;
+  
+  @XStreamAlias("refund_fee")
+  private String refundFee;
+  
+  @XStreamAlias("total_fee")
+  private String totalFee;
+  
+  @XStreamAlias("fee_type")
+  private String feeType;
+  
+  @XStreamAlias("cash_fee")
+  private String cashFee;
+  
+  @XStreamAlias("cash_refund_fee")
+  private String cashRefundfee;
+  
+  @XStreamAlias("coupon_refund_fee")
+  private String couponRefundFee;
+  
+  @XStreamAlias("coupon_refund_count")
+  private String couponRefundCount;
+  
+  @XStreamAlias("coupon_refund_id")
+  private String couponRefundId;
+
+  public String getReturnCode() {
+    return returnCode;
+  }
+  
+  public void setReturnCode(String returnCode) {
+    this.returnCode = returnCode;
+  }
+  
+  public String getReturnMsg() {
+    return returnMsg;
+  }
+  
+  public void setReturnMsg(String returnMsg) {
+    this.returnMsg = returnMsg;
+  }
+  
+  public String getResultCode() {
+    return resultCode;
+  }
+  
+  public void setResultCode(String resultCode) {
+    this.resultCode = resultCode;
+  }
+  
+  public String getErrCode() {
+    return errCode;
+  }
+  
+  public void setErrCode(String errCode) {
+    this.errCode = errCode;
+  }
+  
+  public String getErrCodeDes() {
+    return errCodeDes;
+  }
+  
+  public void setErrCodeDes(String errCodeDes) {
+    this.errCodeDes = errCodeDes;
+  }
+  
+  public String getAppid() {
+    return appid;
+  }
+  
+  public void setAppid(String appid) {
+    this.appid = appid;
+  }
+  
+  public String getMchId() {
+    return mchId;
+  }
+  
+  public void setMchId(String mchId) {
+    this.mchId = mchId;
+  }
+  
+  public String getDeviceInfo() {
+    return deviceInfo;
+  }
+  
+  public void setDeviceInfo(String deviceInfo) {
+    this.deviceInfo = deviceInfo;
+  }
+  
+  public String getNonceStr() {
+    return nonceStr;
+  }
+  
+  public void setNonceStr(String nonceStr) {
+    this.nonceStr = nonceStr;
+  }
+  
+  public String getSign() {
+    return sign;
+  }
+  
+  public void setSign(String sign) {
+    this.sign = sign;
+  }
+  
+  public String getTransactionId() {
+    return transactionId;
+  }
+  
+  public void setTransactionId(String transactionId) {
+    this.transactionId = transactionId;
+  }
+  
+  public String getOutTradeNo() {
+    return outTradeNo;
+  }
+  
+  public void setOutTradeNo(String outTradeNo) {
+    this.outTradeNo = outTradeNo;
+  }
+  
+  public String getOutRefundNo() {
+    return outRefundNo;
+  }
+  
+  public void setOutRefundNo(String outRefundNo) {
+    this.outRefundNo = outRefundNo;
+  }
+  
+  public String getRefundId() {
+    return refundId;
+  }
+  
+  public void setRefundId(String refundId) {
+    this.refundId = refundId;
+  }
+  
+  public String getRefundChannel() {
+    return refundChannel;
+  }
+  
+  public void setRefundChannel(String refundChannel) {
+    this.refundChannel = refundChannel;
+  }
+  
+  public String getRefundFee() {
+    return refundFee;
+  }
+  
+  public void setRefundFee(String refundFee) {
+    this.refundFee = refundFee;
+  }
+  
+  public String getTotalFee() {
+    return totalFee;
+  }
+  
+  public void setTotalFee(String totalFee) {
+    this.totalFee = totalFee;
+  }
+  
+  public String getFeeType() {
+    return feeType;
+  }
+  
+  public void setFeeType(String feeType) {
+    this.feeType = feeType;
+  }
+  
+  public String getCashFee() {
+    return cashFee;
+  }
+  
+  public void setCashFee(String cashFee) {
+    this.cashFee = cashFee;
+  }
+  
+  public String getCashRefundfee() {
+    return cashRefundfee;
+  }
+  
+  public void setCashRefundfee(String cashRefundfee) {
+    this.cashRefundfee = cashRefundfee;
+  }
+  
+  public String getCouponRefundFee() {
+    return couponRefundFee;
+  }
+  
+  public void setCouponRefundFee(String couponRefundFee) {
+    this.couponRefundFee = couponRefundFee;
+  }
+  
+  public String getCouponRefundCount() {
+    return couponRefundCount;
+  }
+  
+  public void setCouponRefundCount(String couponRefundCount) {
+    this.couponRefundCount = couponRefundCount;
+  }
+  
+  public String getCouponRefundId() {
+    return couponRefundId;
+  }
+  
+  public void setCouponRefundId(String couponRefundId) {
+    this.couponRefundId = couponRefundId;
+  }
+  
+  @Override
+  public String toString() {
+    return "[" +
+      "return_code:" + returnCode + ";" +
+      "return_msg" + returnMsg + ";";
+  }
+
+}

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/MaterialDeleteRequestExecutor.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/MaterialDeleteRequestExecutor.java
@@ -34,13 +34,16 @@ public class MaterialDeleteRequestExecutor implements RequestExecutor<Boolean, S
     Map<String, String> params = new HashMap<>();
     params.put("media_id", materialId);
     httpPost.setEntity(new StringEntity(WxGsonBuilder.create().toJson(params)));
-    CloseableHttpResponse response = httpclient.execute(httpPost);
-    String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
-    WxError error = WxError.fromJson(responseContent);
-    if (error.getErrorCode() != 0) {
-      throw new WxErrorException(error);
-    } else {
-      return true;
+    try(CloseableHttpResponse response = httpclient.execute(httpPost)){
+      String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
+      WxError error = WxError.fromJson(responseContent);
+      if (error.getErrorCode() != 0) {
+        throw new WxErrorException(error);
+      } else {
+        return true;
+      }
+    }finally {
+      httpPost.releaseConnection();
     }
   }
 

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/MaterialNewsInfoRequestExecutor.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/MaterialNewsInfoRequestExecutor.java
@@ -35,14 +35,18 @@ public class MaterialNewsInfoRequestExecutor implements RequestExecutor<WxMpMate
     Map<String, String> params = new HashMap<>();
     params.put("media_id", materialId);
     httpPost.setEntity(new StringEntity(WxGsonBuilder.create().toJson(params)));
-    CloseableHttpResponse response = httpclient.execute(httpPost);
-    String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
-    WxError error = WxError.fromJson(responseContent);
-    if (error.getErrorCode() != 0) {
-      throw new WxErrorException(error);
-    } else {
-      return WxMpGsonBuilder.create().fromJson(responseContent, WxMpMaterialNews.class);
+    try(CloseableHttpResponse response = httpclient.execute(httpPost)){
+      String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
+      WxError error = WxError.fromJson(responseContent);
+      if (error.getErrorCode() != 0) {
+        throw new WxErrorException(error);
+      } else {
+        return WxMpGsonBuilder.create().fromJson(responseContent, WxMpMaterialNews.class);
+      }
+    }finally {
+      httpPost.releaseConnection();
     }
+
   }
 
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/MaterialUploadRequestExecutor.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/MaterialUploadRequestExecutor.java
@@ -48,13 +48,16 @@ public class MaterialUploadRequestExecutor implements RequestExecutor<WxMpMateri
       httpPost.setHeader("Content-Type", ContentType.MULTIPART_FORM_DATA.toString());
     }
 
-    CloseableHttpResponse response = httpclient.execute(httpPost);
-    String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
-    WxError error = WxError.fromJson(responseContent);
-    if (error.getErrorCode() != 0) {
-      throw new WxErrorException(error);
-    } else {
-      return WxMpMaterialUploadResult.fromJson(responseContent);
+    try(CloseableHttpResponse response = httpclient.execute(httpPost)){
+      String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
+      WxError error = WxError.fromJson(responseContent);
+      if (error.getErrorCode() != 0) {
+        throw new WxErrorException(error);
+      } else {
+        return WxMpMaterialUploadResult.fromJson(responseContent);
+      }
+    }finally {
+      httpPost.releaseConnection();
     }
   }
 

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/MaterialVideoInfoRequestExecutor.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/MaterialVideoInfoRequestExecutor.java
@@ -34,13 +34,16 @@ public class MaterialVideoInfoRequestExecutor implements RequestExecutor<WxMpMat
     Map<String, String> params = new HashMap<>();
     params.put("media_id", materialId);
     httpPost.setEntity(new StringEntity(WxGsonBuilder.create().toJson(params)));
-    CloseableHttpResponse response = httpclient.execute(httpPost);
-    String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
-    WxError error = WxError.fromJson(responseContent);
-    if (error.getErrorCode() != 0) {
-      throw new WxErrorException(error);
-    } else {
-      return WxMpMaterialVideoInfoResult.fromJson(responseContent);
+    try(CloseableHttpResponse response = httpclient.execute(httpPost)){
+      String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
+      WxError error = WxError.fromJson(responseContent);
+      if (error.getErrorCode() != 0) {
+        throw new WxErrorException(error);
+      } else {
+        return WxMpMaterialVideoInfoResult.fromJson(responseContent);
+      }
+    }finally {
+      httpPost.releaseConnection();
     }
   }
 

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/MaterialVoiceAndImageDownloadRequestExecutor.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/MaterialVoiceAndImageDownloadRequestExecutor.java
@@ -44,22 +44,25 @@ public class MaterialVoiceAndImageDownloadRequestExecutor implements RequestExec
     Map<String, String> params = new HashMap<>();
     params.put("media_id", materialId);
     httpPost.setEntity(new StringEntity(WxGsonBuilder.create().toJson(params)));
-    CloseableHttpResponse response = httpclient.execute(httpPost);
-    // 下载媒体文件出错
-    InputStream inputStream = InputStreamResponseHandler.INSTANCE.handleResponse(response);
-    byte[] responseContent = IOUtils.toByteArray(inputStream);
-    String responseContentString = new String(responseContent, "UTF-8");
-    if (responseContentString.length() < 100) {
-      try {
-        WxError wxError = WxGsonBuilder.create().fromJson(responseContentString, WxError.class);
-        if (wxError.getErrorCode() != 0) {
-          throw new WxErrorException(wxError);
+    try(CloseableHttpResponse response = httpclient.execute(httpPost)){
+      // 下载媒体文件出错
+      InputStream inputStream = InputStreamResponseHandler.INSTANCE.handleResponse(response);
+      byte[] responseContent = IOUtils.toByteArray(inputStream);
+      String responseContentString = new String(responseContent, "UTF-8");
+      if (responseContentString.length() < 100) {
+        try {
+          WxError wxError = WxGsonBuilder.create().fromJson(responseContentString, WxError.class);
+          if (wxError.getErrorCode() != 0) {
+            throw new WxErrorException(wxError);
+          }
+        } catch (com.google.gson.JsonSyntaxException ex) {
+          return new ByteArrayInputStream(responseContent);
         }
-      } catch (com.google.gson.JsonSyntaxException ex) {
-        return new ByteArrayInputStream(responseContent);
       }
+      return new ByteArrayInputStream(responseContent);
+    }finally {
+      httpPost.releaseConnection();
     }
-    return new ByteArrayInputStream(responseContent);
   }
 
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/QrCodeRequestExecutor.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/http/QrCodeRequestExecutor.java
@@ -58,8 +58,9 @@ public class QrCodeRequestExecutor implements RequestExecutor<File, WxMpQrCodeTi
       }
       InputStream inputStream = InputStreamResponseHandler.INSTANCE.handleResponse(response);
 
-      File localFile = FileUtils.createTmpFile(inputStream, UUID.randomUUID().toString(), "jpg");
-      return localFile;
+      return FileUtils.createTmpFile(inputStream, UUID.randomUUID().toString(), "jpg");
+    }finally {
+      httpGet.releaseConnection();
     }
 
   }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpCardGsonAdapter.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpCardGsonAdapter.java
@@ -1,0 +1,38 @@
+package me.chanjar.weixin.mp.util.json;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
+import me.chanjar.weixin.common.util.json.GsonHelper;
+import me.chanjar.weixin.mp.bean.WxMpCard;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * Created by YuJian on 15/11/11.
+ *
+ * @author YuJian
+ * @version 15/11/11
+ */
+public class WxMpCardGsonAdapter implements JsonDeserializer<WxMpCard> {
+
+  @Override
+  public WxMpCard deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext
+      jsonDeserializationContext) throws JsonParseException {
+    WxMpCard card = new WxMpCard();
+    JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+    card.setCardId(GsonHelper.getString(jsonObject, "card_id"));
+    card.setBeginTime(GsonHelper.getLong(jsonObject, "begin_time"));
+    card.setEndTime(GsonHelper.getLong(jsonObject, "end_time"));
+
+    return card;
+  }
+
+}

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpCardResultGsonAdapter.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpCardResultGsonAdapter.java
@@ -1,0 +1,45 @@
+package me.chanjar.weixin.mp.util.json;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
+import me.chanjar.weixin.common.util.json.GsonHelper;
+import me.chanjar.weixin.mp.bean.WxMpCard;
+import me.chanjar.weixin.mp.bean.result.WxMpCardResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.util.List;
+
+/**
+ * Created by YuJian on 15/11/11.
+ *
+ * @author YuJian
+ * @version 15/11/11
+ */
+public class WxMpCardResultGsonAdapter implements JsonDeserializer<WxMpCardResult> {
+  @Override
+  public WxMpCardResult deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+    WxMpCardResult cardResult = new WxMpCardResult();
+    JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+    cardResult.setOpenId(GsonHelper.getString(jsonObject, "openid"));
+    cardResult.setErrorCode(GsonHelper.getString(jsonObject, "errcode"));
+    cardResult.setErrorMsg(GsonHelper.getString(jsonObject, "errmsg"));
+    cardResult.setCanConsume(GsonHelper.getBoolean(jsonObject, "can_consume"));
+    cardResult.setUserCardStatus(GsonHelper.getString(jsonObject, "user_card_status"));
+
+    WxMpCard card = WxMpGsonBuilder.INSTANCE.create().fromJson(jsonObject.get("card"),
+        new TypeToken<WxMpCard>() {
+        }.getType());
+
+    cardResult.setCard(card);
+
+    return cardResult;
+  }
+}

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpGsonBuilder.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpGsonBuilder.java
@@ -38,6 +38,8 @@ public class WxMpGsonBuilder {
     INSTANCE.registerTypeAdapter(WxMpMaterialNewsBatchGetResult.WxMaterialNewsBatchGetNewsItem.class, new WxMpMaterialNewsBatchGetGsonItemAdapter());
     INSTANCE.registerTypeAdapter(WxMpMaterialFileBatchGetResult.class, new WxMpMaterialFileBatchGetGsonAdapter());
     INSTANCE.registerTypeAdapter(WxMpMaterialFileBatchGetResult.WxMaterialFileBatchGetNewsItem.class, new WxMpMaterialFileBatchGetGsonItemAdapter());
+    INSTANCE.registerTypeAdapter(WxMpCardResult.class, new WxMpCardResultGsonAdapter());
+    INSTANCE.registerTypeAdapter(WxMpCard.class, new WxMpCardGsonAdapter());
   }
 
   public static Gson create() {

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/xml/XStreamTransformer.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/xml/XStreamTransformer.java
@@ -32,6 +32,16 @@ public class XStreamTransformer {
   }
 
   /**
+   * 注册扩展消息的解析器
+   * @param clz 类型
+   * @param xStream xml解析器
+   */
+  public static void register(Class clz,XStream xStream){
+    CLASS_2_XSTREAM_INSTANCE.put(clz,xStream);
+  }
+
+
+  /**
    * pojo -> xml
    *
    * @param clazz

--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/bean/WxMpXmlOutTransferCustomerServiceMessageTest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/bean/WxMpXmlOutTransferCustomerServiceMessageTest.java
@@ -1,0 +1,70 @@
+package me.chanjar.weixin.mp.bean;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Created by ben on 2015/12/29.
+ */
+public class WxMpXmlOutTransferCustomerServiceMessageTest {
+  @Test
+  public void test() {
+    WxMpXmlOutTransferCustomerServiceMessage m = new WxMpXmlOutTransferCustomerServiceMessage();
+    m.setCreateTime(1399197672L);
+    m.setFromUserName("fromuser");
+    m.setToUserName("touser");
+
+    String expected = "<xml>" +
+      "<ToUserName><![CDATA[touser]]></ToUserName>" +
+      "<FromUserName><![CDATA[fromuser]]></FromUserName>" +
+      "<CreateTime>1399197672</CreateTime>" +
+      "<MsgType><![CDATA[transfer_customer_service]]></MsgType>" +
+      "</xml>";
+    System.out.println(m.toXml());
+    Assert.assertEquals(m.toXml().replaceAll("\\s", ""), expected.replaceAll("\\s", ""));
+
+    expected = " <xml>" +
+      "<ToUserName><![CDATA[touser]]></ToUserName>" +
+      "<FromUserName><![CDATA[fromuser]]></FromUserName>" +
+      "<CreateTime>1399197672</CreateTime>" +
+      "<MsgType><![CDATA[transfer_customer_service]]></MsgType>" +
+      "<TransInfo>" +
+      "<KfAccount><![CDATA[test1@test]]></KfAccount>" +
+      "</TransInfo>" +
+      "</xml>";
+    WxMpXmlOutTransferCustomerServiceMessage.TransInfo transInfo = new WxMpXmlOutTransferCustomerServiceMessage.TransInfo();
+    transInfo.setKfAccount("test1@test");
+    m.setTransInfo(transInfo);
+    System.out.println(m.toXml());
+    Assert.assertEquals(m.toXml().replaceAll("\\s", ""), expected.replaceAll("\\s", ""));
+  }
+
+  @Test
+  public void testBuild() {
+    WxMpXmlOutTransferCustomerServiceMessage m = WxMpXmlOutMessage.TRANSFER_CUSTOMER_SERVICE().fromUser("fromuser").toUser("touser").build();
+    m.setCreateTime(1399197672L);
+    String expected = "<xml>" +
+      "<ToUserName><![CDATA[touser]]></ToUserName>" +
+      "<FromUserName><![CDATA[fromuser]]></FromUserName>" +
+      "<CreateTime>1399197672</CreateTime>" +
+      "<MsgType><![CDATA[transfer_customer_service]]></MsgType>" +
+      "</xml>";
+    System.out.println(m.toXml());
+    Assert.assertEquals(m.toXml().replaceAll("\\s", ""), expected.replaceAll("\\s", ""));
+
+
+    expected = " <xml>" +
+      "<ToUserName><![CDATA[touser]]></ToUserName>" +
+      "<FromUserName><![CDATA[fromuser]]></FromUserName>" +
+      "<CreateTime>1399197672</CreateTime>" +
+      "<MsgType><![CDATA[transfer_customer_service]]></MsgType>" +
+      "<TransInfo>" +
+      "<KfAccount><![CDATA[test1@test]]></KfAccount>" +
+      "</TransInfo>" +
+      "</xml>";
+    m = WxMpXmlOutMessage.TRANSFER_CUSTOMER_SERVICE().kfAccount("test1@test").fromUser("fromuser").toUser("touser").build();
+    m.setCreateTime(1399197672L);
+    System.out.println(m.toXml());
+    Assert.assertEquals(m.toXml().replaceAll("\\s", ""), expected.replaceAll("\\s", ""));
+  }
+}


### PR DESCRIPTION
更新 WxMpServiceImpl.java和WxMpService.java类，增加扫码支付参数拼装。
1.将原来的getJSSDKPayInfo(Map<String, String> parameters)方法修改为getPayInfo(Map<String, String> parameters)方法增加返回参数codeUrl的判断，只有native方式才返回codeUrl参数。
2.将原来的getJSSDKPayInfo(String openId, String outTradeNo, double amt, String body, String tradeType, String ip, String notifyUrl);方法拆分为两个：
   1）公众号支付jspai统一下单参数拼装方法：Map<String, String> getJsapiPayInfo(String openId, String outTradeNo, double amt, String body, String ip, String notifyUrl);
 2） 扫码支付native统一下单参数拼装方法：Map<String, String> getNativePayInfo(String productId, String outTradeNo, double amt, String body, String ip, String notifyUrl);
