### PR TITLE
微信个性化菜单接口group_id改为tag_id

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxMenu.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxMenu.java
@@ -129,7 +129,7 @@ public class WxMenu implements Serializable {
   }
   
   public static class WxMenuRule {
-    private String groupId;
+    private String tagId;
     private String sex;
     private String country;
     private String province;
@@ -137,12 +137,12 @@ public class WxMenu implements Serializable {
     private String clientPlatformType;
     private String language;
     
-    public String getGroupId() {
-      return groupId;
+    public String getTagId() {
+      return tagId;
     }
 	
-    public void setGroupId(String groupId) {
-      this.groupId = groupId;
+    public void setTagId(String tagId) {
+      this.tagId = tagId;
     }
 	
     public String getSex() {
@@ -196,7 +196,7 @@ public class WxMenu implements Serializable {
       @Override
     public String toString() {
       return "matchrule:{" +
-          "group_id='" + groupId + '\'' +
+          "tag_id='" + tagId + '\'' +
           ", sex='" + sex + '\'' +
           ", country" + country + '\'' +
           ", province" + province + '\'' +

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/json/WxMenuGsonAdapter.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/json/WxMenuGsonAdapter.java
@@ -62,7 +62,7 @@ public class WxMenuGsonAdapter implements JsonSerializer<WxMenu>, JsonDeserializ
 
   protected JsonObject convertToJson(WxMenu.WxMenuRule menuRule){
     JsonObject matchRule = new JsonObject();
-    matchRule.addProperty("group_id",menuRule.getGroupId());
+    matchRule.addProperty("tag_id",menuRule.getTagId());
     matchRule.addProperty("sex",menuRule.getSex());
     matchRule.addProperty("country",menuRule.getCountry());
     matchRule.addProperty("province",menuRule.getProvince());

--- a/weixin-java-common/src/test/java/me/chanjar/weixin/common/bean/WxMenuTest.java
+++ b/weixin-java-common/src/test/java/me/chanjar/weixin/common/bean/WxMenuTest.java
@@ -67,7 +67,7 @@ public class WxMenuTest {
     menu.getButtons().add(button1);
 
     WxMenu.WxMenuRule wxMenuRule = new WxMenu.WxMenuRule();
-    wxMenuRule.setGroupId("2");
+    wxMenuRule.setTagId("2");
     wxMenuRule.setSex("1");
     wxMenuRule.setCountry("中国");
     wxMenuRule.setProvince("广东");


### PR DESCRIPTION
详细参见http://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1455782296&token=&lang=zh_CN
